### PR TITLE
fix(deploy): chmod graceful on read-only ROAST mount, remove UI from …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,5 +55,4 @@ SIMNIBS_TIMEOUT_SECONDS=10800
 # -----------------------------------------------------------------------------
 # Frontend
 # -----------------------------------------------------------------------------
-# Public URL of the backend API — baked into the Next.js build at image-build time
-NEXT_PUBLIC_API_URL=http://10.15.224.253:8000
+# Frontend is deployed on Vercel — set NEXT_PUBLIC_API_URL there, not here.

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -39,7 +39,7 @@ jobs:
             echo "[deploy] Rebuilding and restarting containers..."
             cd /home/chintan/GRACE-Web-Tool
             docker compose down || true
-            docker compose build api ui
+            docker compose build api
             docker compose up -d
 
             echo "[deploy] Checking container status..."

--- a/api_v2/app.py
+++ b/api_v2/app.py
@@ -56,14 +56,17 @@ async def lifespan(app: FastAPI):
     t3.start()
     print("Session cleanup scheduler started (30-day retention)")
 
-    # Ensure ROAST binaries are executable
+    # Ensure ROAST binaries are executable (best-effort — skipped on read-only mounts)
     import stat
     from config import ROAST_BUILD_DIR
     for binary in ["roast_run", "run_roast_run.sh"]:
         p = ROAST_BUILD_DIR / binary
         if p.exists():
-            p.chmod(p.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-            print(f"chmod +x {p}")
+            try:
+                p.chmod(p.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+                print(f"chmod +x {p}")
+            except OSError:
+                print(f"[warn] chmod skipped for {p} (read-only mount — ensure host file is executable)")
 
     yield
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,19 +70,19 @@ services:
               count: all
               capabilities: [gpu]
 
-  # CROWN frontend
-  ui:
-    build:
-      context: ./ui_v2
-      dockerfile: Dockerfile
-      args:
-        - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://10.15.224.253:8000}
-    container_name: whs-ui
-    restart: unless-stopped
-    ports:
-      - "3000:3000"
-    depends_on:
-      - api
+  # CROWN frontend — deployed on Vercel, not run here
+  # ui:
+  #   build:
+  #     context: ./ui_v2
+  #     dockerfile: Dockerfile
+  #     args:
+  #       - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://10.15.224.253:8000}
+  #   container_name: whs-ui
+  #   restart: unless-stopped
+  #   ports:
+  #     - "3000:3000"
+  #   depends_on:
+  #     - api
 
 volumes:
   redis_data:


### PR DESCRIPTION
…compose

- Catch OSError in ROAST binary chmod at startup — mount is :ro so chmod fails; binaries should already be executable on the host
- Comment out UI service in docker-compose (frontend is on Vercel)
- CI/CD: build only api container, not ui
- .env.example: note that NEXT_PUBLIC_API_URL is set in Vercel