### PR TITLE
fix(ui): correct ROAST timing, cold-start note, and transparent label…

### DIFF
--- a/ui_v2/app/components/Viewer.tsx
+++ b/ui_v2/app/components/Viewer.tsx
@@ -108,7 +108,12 @@ export default function Viewer({ inputUrl, sessionId, models, progress }: Props)
             await nv.loadFromArrayBuffer(buffer, `${model}.nii.gz`);
 
             // Set colormap for segmentation - use freesurfer for label visualization
-            nv.setColormap(nv.volumes[1].id, "freesurfer");
+            if (nv.volumes.length > 1) {
+              const vol = nv.volumes[1];
+              vol.cal_min = 0;
+              vol.cal_max = 11; // 12 tissue classes: labels 0-11
+              nv.setColormap(vol.id, "freesurfer");
+            }
             nv.setOpacity(1, 0.5); // Semi-transparent overlay
             nv.drawScene();
 

--- a/ui_v2/app/components/tes/TESPage.tsx
+++ b/ui_v2/app/components/tes/TESPage.tsx
@@ -605,7 +605,9 @@ export default function TESPage() {
                 ))}
               </div>
               <p className="mt-1.5 text-[11px] text-foreground-muted">
-                {quality === "fast" ? "~20–35 min, coarser mesh" : "~40–60 min, full resolution"}
+                {quality === "fast" ? "~10–15 min, coarser mesh" : "~20–30 min, full resolution"}
+                {" · "}
+                <span className="opacity-60">first run may be 3–5 min longer</span>
               </p>
             </div>
           )}

--- a/ui_v2/app/components/tes/TESWizard.tsx
+++ b/ui_v2/app/components/tes/TESWizard.tsx
@@ -453,7 +453,7 @@ export default function TESWizard({ sessionId, models, inputBlobUrl }: TESWizard
                 quality === "fast" ? "bg-accent text-white" : "text-foreground-muted hover:bg-surface-elevated",
               )}
             >
-              ⚡ Fast (~20–35 min)
+              ⚡ Fast (~10–15 min)
             </button>
             <button
               type="button"
@@ -463,11 +463,14 @@ export default function TESWizard({ sessionId, models, inputBlobUrl }: TESWizard
                 quality === "standard" ? "bg-accent text-white" : "text-foreground-muted hover:bg-surface-elevated",
               )}
             >
-              🎯 Standard (~40–60 min)
+              🎯 Standard (~20–30 min)
             </button>
           </div>
           <p className="text-xs text-foreground-muted">
             {quality === "fast" ? "Coarser mesh, faster solve — good for exploration." : "Full mesh resolution — recommended for final results."}
+          </p>
+          <p className="text-[11px] text-foreground-muted/60 mt-1">
+            First run after deploy may take 3–5 min longer (runtime cache cold start).
           </p>
         </div>
       )}


### PR DESCRIPTION
… patch

- ROAST timing: fast ~10-15 min, standard ~20-30 min (based on real test data)
- Add note that first run after deploy takes 3-5 min longer (MCR cold start)
- Fix transparent tissue label in viewer: set cal_min=0 cal_max=11 so all 12 labels map correctly to the FreeSurfer colormap LUT