### PR TITLE
fix: flush CUDA cache before GPU release; raise ROAST stall timeout t…

### DIFF
--- a/api_v2/runtime/roast_runner.py
+++ b/api_v2/runtime/roast_runner.py
@@ -248,7 +248,7 @@ class ROASTRunner:
 
             last_progress = 5
             deadline = time.time() + ROAST_TIMEOUT_SECONDS
-            STALL_TIMEOUT = 300  # kill if ROAST produces no stdout for 5 min
+            STALL_TIMEOUT = 1800  # kill if ROAST produces no stdout for 30 min
 
             while True:
                 ready, _, _ = select.select([proc.stdout], [], [], STALL_TIMEOUT)

--- a/api_v2/runtime/scheduler.py
+++ b/api_v2/runtime/scheduler.py
@@ -114,6 +114,13 @@ class GPUScheduler:
             set_job_status(job_id, model_name, "error")
             return (model_name, False, str(e))
         finally:
+            # Flush PyTorch CUDA cache before marking GPU free so the next
+            # acquire_gpu sees accurate free VRAM from nvidia-smi.
+            try:
+                import torch
+                torch.cuda.empty_cache()
+            except Exception:
+                pass
             self.release_gpu(gpu_id, job_id)
 
     def run_job(self, job_id: str):


### PR DESCRIPTION
…o 30 min

- scheduler.py: call torch.cuda.empty_cache() in the finally block before release_gpu() so nvidia-smi reports accurate free VRAM; without this, PyTorch's allocator holds cached memory and acquire_gpu's 4096 MiB check skips the newly-freed GPU, blocking subsequent models from starting
- roast_runner.py: raise STALL_TIMEOUT from 300s to 1800s (30 min)