### PR TITLE
fix(roast): force line-buffered stdout with stdbuf to prevent apparen…

### DIFF
--- a/api_v2/runtime/roast_runner.py
+++ b/api_v2/runtime/roast_runner.py
@@ -227,6 +227,12 @@ class ROASTRunner:
         if _shutil.which("xvfb-run"):
             cmd = ["xvfb-run", "-a", "--server-args=-screen 0 1x1x24"] + cmd
 
+        # Force line-buffered stdout so MCR flushes after every \n instead of
+        # accumulating output in an 8KB block buffer (which causes apparent stalls
+        # during pure-MATLAB phases like drawCuboid that make no system calls).
+        if _shutil.which("stdbuf"):
+            cmd = ["stdbuf", "-oL"] + cmd
+
         return cmd
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
…t stalls

MCR uses block-buffered stdout when piped, holding output in an 8KB buffer until a system call flushes it. Pure-MATLAB phases (drawCuboid, sub2ind, eig) make no system calls so output silently accumulates. stdbuf -oL forces flush on every newline, making all progress fprintf/disp lines appear immediately.