### PR TITLE
fix(roast): remove xvfb-run to fix pty stdout buffering in Docker

### DIFF
--- a/api_v2/runtime/roast_runner.py
+++ b/api_v2/runtime/roast_runner.py
@@ -220,14 +220,8 @@ class ROASTRunner:
         session_log(self.session_id, f"[ROAST] Using MCR at: {mcr}")
 
         cmd = [str(launcher), str(mcr), str(config_path)]
-
-        # MCR initialises GUI plugins (CEF/web window manager) even in headless
-        # environments.  Wrap with xvfb-run so it gets a virtual display instead
-        # of hard-failing with missing libgbm / libnss3 errors.
-        import shutil as _shutil
-        if _shutil.which("xvfb-run"):
-            cmd = ["xvfb-run", "-a", "--server-args=-screen 0 1x1x24"] + cmd
-
+        # Binary compiled with -nodisplay so MCR needs no X server.
+        # xvfb-run breaks the pty slave fd chain causing stdout block-buffering.
         return cmd
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
xvfb-run breaks the pty slave fd chain, causing MCR to fall back to block-buffering and stall at 19% (placing electrodes) in Docker. The binary is compiled with -nodisplay so no X server is needed.