### PR TITLE
feat(legend): click to isolate tissue class in segmentation viewer

### DIFF
--- a/ui_v2/app/components/viewer/SegmentationLegend.tsx
+++ b/ui_v2/app/components/viewer/SegmentationLegend.tsx
@@ -21,35 +21,28 @@ const TISSUE_LABELS = [
 
 const MAX_LABEL = 11;
 
-// Mirror of TISSUE_COLORS in SplitViewer.tsx for the "grace_seg_tissues" case.
-// The viewer registers the LUT under a fixed key rather than "grace_seg_tissues",
-// so we keep these here to render the legend without needing the Niivue instance.
 const GRACE_TISSUE_COLORS: [number, number, number][] = [
-  [  0,   0,   0],  //  0: background
-  [240, 240, 240],  //  1: white matter
-  [120, 100, 100],  //  2: gray matter
-  [100, 180, 230],  //  3: CSF
-  [200, 160,  80],  //  4: compact bone
-  [230, 200, 130],  //  5: spongy bone
-  [250, 170, 100],  //  6: scalp
-  [ 40,  40,  80],  //  7: air cavities
-  [180,  40,  40],  //  8: muscle
-  [255, 230, 100],  //  9: fat
-  [210,  10,  30],  // 10: blood
-  [  0, 200, 180],  // 11: eye
+  [  0,   0,   0],
+  [240, 240, 240],
+  [120, 100, 100],
+  [100, 180, 230],
+  [200, 160,  80],
+  [230, 200, 130],
+  [250, 170, 100],
+  [ 40,  40,  80],
+  [180,  40,  40],
+  [255, 230, 100],
+  [210,  10,  30],
+  [  0, 200, 180],
 ];
 
 function getLabelColors(colormapName: ColormapId): string[] {
-  // "grace_seg_tissues" uses hand-crafted tissue colors not registered in cmapper.
   if (colormapName === "grace_seg_tissues") {
     return TISSUE_LABELS.map(({ id }) => {
       const [r, g, b] = GRACE_TISSUE_COLORS[id];
       return `rgb(${r}, ${g}, ${b})`;
     });
   }
-
-  // For all other colormaps, sample the interpolated 256-entry LUT at the
-  // same 12 positions the viewer uses — this keeps the legend in sync.
   const lut = cmapper.colormap(colormapName);
   return TISSUE_LABELS.map(({ id }) => {
     if (id === 0) return "rgb(0, 0, 0)";
@@ -60,13 +53,14 @@ function getLabelColors(colormapName: ColormapId): string[] {
 
 interface SegmentationLegendProps {
   colormap: ColormapId;
-  hoveredLabel?: number | null;
-  onLabelHover?: (labelId: number | null) => void;
+  selectedLabel?: number | null;
+  onLabelSelect?: (labelId: number) => void;
 }
 
-export default function SegmentationLegend({ colormap, hoveredLabel = null, onLabelHover }: SegmentationLegendProps) {
+export default function SegmentationLegend({ colormap, selectedLabel = null, onLabelSelect }: SegmentationLegendProps) {
   const colors = useMemo(() => getLabelColors(colormap), [colormap]);
-  const isFiltering = hoveredLabel !== null;
+  const isFiltering = selectedLabel !== null;
+  const selectedTissue = isFiltering ? TISSUE_LABELS.find(t => t.id === selectedLabel) : null;
 
   return (
     <div
@@ -75,41 +69,56 @@ export default function SegmentationLegend({ colormap, hoveredLabel = null, onLa
       aria-label="Segmentation tissue legend"
     >
       <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
-        <span className="text-xs font-semibold uppercase tracking-wider text-foreground-muted">
-          Legend
-        </span>
+        <div className="flex items-center gap-2 shrink-0">
+          <span className="text-xs font-semibold uppercase tracking-wider text-foreground-muted">
+            Legend
+          </span>
+          {isFiltering ? (
+            <span className="rounded bg-accent/15 px-1.5 py-0.5 text-[10px] font-medium text-accent">
+              {selectedTissue?.label} only
+            </span>
+          ) : (
+            <span className="text-[10px] text-foreground-muted italic">
+              click to isolate
+            </span>
+          )}
+        </div>
+
         <div className="h-4 w-px bg-border hidden sm:block" aria-hidden="true" />
+
         {TISSUE_LABELS.map((tissue, i) => {
-          const isHovered = hoveredLabel === tissue.id;
-          const isDimmed  = isFiltering && !isHovered;
+          const isSelected = selectedLabel === tissue.id;
+          const isDimmed   = isFiltering && !isSelected;
           return (
-            <div
+            <button
               key={tissue.id}
-              className="flex items-center gap-1.5 cursor-pointer select-none transition-opacity duration-150"
+              type="button"
+              onClick={() => onLabelSelect?.(tissue.id)}
+              title={isSelected ? `Click to show all` : `Click to isolate ${tissue.label}`}
+              className="flex items-center gap-1.5 select-none transition-opacity duration-150 focus:outline-none"
               style={{ opacity: isDimmed ? 0.2 : 1 }}
-              onMouseEnter={() => onLabelHover?.(tissue.id)}
-              onMouseLeave={() => onLabelHover?.(null)}
-              title={tissue.label}
             >
               <span
                 className="inline-block h-3 w-3 flex-shrink-0 rounded-[3px] ring-1 ring-white/10 transition-transform duration-150"
                 style={{
                   backgroundColor: colors[i],
-                  transform: isHovered ? "scale(1.4)" : "scale(1)",
+                  transform: isSelected ? "scale(1.5)" : "scale(1)",
+                  boxShadow: isSelected ? `0 0 0 2px white, 0 0 0 3px ${colors[i]}` : undefined,
                 }}
                 aria-hidden="true"
               />
-              <span className={`text-xs whitespace-nowrap transition-colors duration-150 ${isHovered ? "font-semibold text-foreground" : "text-foreground-secondary"}`}>
+              <span className={`text-xs whitespace-nowrap transition-colors duration-150 ${isSelected ? "font-semibold text-foreground" : "text-foreground-secondary"}`}>
                 {tissue.label}
               </span>
-            </div>
+            </button>
           );
         })}
+
         {isFiltering && (
           <button
-            className="ml-auto text-[10px] text-foreground-muted hover:text-foreground underline underline-offset-2 transition-colors"
-            onMouseEnter={() => onLabelHover?.(null)}
-            onClick={() => onLabelHover?.(null)}
+            type="button"
+            onClick={() => selectedLabel !== null && onLabelSelect?.(selectedLabel)}
+            className="ml-auto text-[10px] text-foreground-muted hover:text-foreground underline underline-offset-2 transition-colors shrink-0"
           >
             Show all
           </button>

--- a/ui_v2/app/components/viewer/SplitViewer.tsx
+++ b/ui_v2/app/components/viewer/SplitViewer.tsx
@@ -116,7 +116,7 @@ export default function SplitViewer({ inputUrl, sessionId, models }: SplitViewer
   const [error, setError] = useState<string | null>(null);
   const [showBgLeft, setShowBgLeft] = useState(false);
   const [showBgRight, setShowBgRight] = useState(false);
-  const [hoveredLabel, setHoveredLabel] = useState<number | null>(null);
+  const [selectedLabel, setSelectedLabel] = useState<number | null>(null);
 
   // Ref to track loaded results without stale closure issues
   const loadedResultsRef = useRef<Record<string, ArrayBuffer>>({});
@@ -449,7 +449,7 @@ export default function SplitViewer({ inputUrl, sessionId, models }: SplitViewer
 
   // Handle model selection for left panel
   const handleLeftModelChange = async (model: string | null) => {
-    setHoveredLabel(null);
+    setSelectedLabel(null);
     const success = await loadOverlayToPanel(leftNvRef.current, model, overlayOpacity, colormap, showBgLeft);
     if (success) {
       setLeftModel(model);
@@ -458,7 +458,7 @@ export default function SplitViewer({ inputUrl, sessionId, models }: SplitViewer
 
   // Handle model selection for right panel
   const handleRightModelChange = async (model: string | null) => {
-    setHoveredLabel(null);
+    setSelectedLabel(null);
     const success = await loadOverlayToPanel(rightNvRef.current, model, overlayOpacity, colormap, showBgRight);
     if (success) {
       setRightModel(model);
@@ -480,14 +480,14 @@ export default function SplitViewer({ inputUrl, sessionId, models }: SplitViewer
   }, [viewMode, initialized]);
 
 
-  // Update colormap, background toggle, or hovered label for either panel
+  // Update colormap, background toggle, or selected label for either panel
   useEffect(() => {
     if (!initialized) return;
     if (leftNvRef.current && leftModel !== null)
-      applySegColormap(leftNvRef.current, colormap, showBgLeft, overlayOpacity, hoveredLabel);
+      applySegColormap(leftNvRef.current, colormap, showBgLeft, overlayOpacity, selectedLabel);
     if (rightNvRef.current && rightModel !== null)
-      applySegColormap(rightNvRef.current, colormap, showBgRight, overlayOpacity, hoveredLabel);
-  }, [colormap, showBgLeft, showBgRight, initialized, leftModel, rightModel, overlayOpacity, hoveredLabel, applySegColormap]);
+      applySegColormap(rightNvRef.current, colormap, showBgRight, overlayOpacity, selectedLabel);
+  }, [colormap, showBgLeft, showBgRight, initialized, leftModel, rightModel, overlayOpacity, selectedLabel, applySegColormap]);
 
   // Get display names
   const getDisplayName = (model: string): string => {
@@ -736,8 +736,8 @@ export default function SplitViewer({ inputUrl, sessionId, models }: SplitViewer
       {/* Segmentation Legend */}
       <SegmentationLegend
         colormap={colormap}
-        hoveredLabel={hoveredLabel}
-        onLabelHover={setHoveredLabel}
+        selectedLabel={selectedLabel}
+        onLabelSelect={(id) => setSelectedLabel(prev => prev === id ? null : id)}
       />
 
       {/* Debug info in development */}


### PR DESCRIPTION
Replace hover with click-to-toggle isolation. Clicking a tissue label shows only that class in both Niivue panels (others dimmed to alpha=25). Clicking the same label again restores all. Legend shows 'click to isolate' hint when idle, and '[Tissue] only' badge + 'Show all' button when active. Selected swatch scales up with a ring highlight.