### PR TITLE
fix(legend): force Niivue GL texture re-upload on label selection

### DIFF
--- a/ui_v2/app/components/viewer/SplitViewer.tsx
+++ b/ui_v2/app/components/viewer/SplitViewer.tsx
@@ -147,8 +147,12 @@ export default function SplitViewer({ inputUrl, sessionId, models }: SplitViewer
       ? buildGraceLUT(showBg, hovered)
       : buildSteppedLUT(cmap, showBg, hovered);
 
-    nv.addColormap(OVERLAY_CMAP_KEY, lut);
-    vol.colormap = OVERLAY_CMAP_KEY;
+    // Encode the selected label in the colormap key so Niivue always sees a new
+    // colormap name and re-uploads the GL texture. Reusing the same key with
+    // updated LUT data is silently ignored because vol.colormap hasn't changed.
+    const cmapKey = hovered !== null ? `${OVERLAY_CMAP_KEY}_l${hovered}` : `${OVERLAY_CMAP_KEY}_all`;
+    nv.addColormap(cmapKey, lut);
+    vol.colormap = cmapKey;
 
     // Pin the cal range so all 12 labels span the full LUT.
     // Also set robust_min/max to prevent updateGLVolume from overriding them.


### PR DESCRIPTION
When vol.colormap was already set to OVERLAY_CMAP_KEY, Niivue detected no change and skipped re-uploading the LUT to the GPU — so clicking a tissue label updated the legend UI but the viewer stayed unchanged.

Fix: encode the selected label into the colormap key (__grace_overlay_l0 ... __grace_overlay_l11, __grace_overlay_all) so vol.colormap always changes, forcing Niivue to re-upload the texture on every selection.