### PR TITLE
feat(roast): auto-retry on mesh/FEM failure + clarify voltage viewer

### DIFF
--- a/api_v2/runtime/roast_runner.py
+++ b/api_v2/runtime/roast_runner.py
@@ -20,7 +20,7 @@ import numpy as np
 from scipy import ndimage as ndi
 
 from config import ROAST_BUILD_DIR, MATLAB_RUNTIME, ROAST_TIMEOUT_SECONDS
-from runtime.roast_config import build_roast_config
+from runtime.roast_config import build_roast_config, DEFAULT_MESH_OPTIONS
 from runtime.session import (
     session_input_native,
     session_input_fs,
@@ -295,9 +295,213 @@ class ROASTRunner:
         return cmd
 
     # ------------------------------------------------------------------
+    def _run_subprocess(self, cmd: list[str], progress_start: int = 5) -> tuple[bool, str | None, int]:
+        """
+        Launch the ROAST binary, stream stdout, and parse progress events.
+
+        Returns (convergence_failed, error_message, last_progress).
+        convergence_failed=True means a retryable mesh/FEM issue was detected.
+        error_message is non-None when the process exited non-zero.
+        """
+        import threading as _threading
+        _home = Path(os.environ.get("HOME", str(Path.home())))
+        mcr_cache = _home / ".MathWorks" / "MatlabRuntimeCache"
+
+        def _chmod_mcr(stop_evt: "_threading.Event"):
+            while not stop_evt.is_set():
+                if mcr_cache.exists():
+                    for _p in mcr_cache.rglob("*.mexa64"):
+                        try:
+                            _p.chmod(_p.stat().st_mode | 0o111)
+                        except OSError:
+                            pass
+                    for _p in mcr_cache.rglob("*"):
+                        if _p.is_file() and not _p.suffix:
+                            try:
+                                _p.chmod(_p.stat().st_mode | 0o111)
+                            except OSError:
+                                pass
+                stop_evt.wait(timeout=0.5)
+
+        _chmod_stop = _threading.Event()
+        _threading.Thread(target=_chmod_mcr, args=(_chmod_stop,), daemon=True).start()
+
+        import os as _os
+        from config import ROAST_MAX_WORKERS as _MAX_W
+        try:
+            total_cpus = len(_os.sched_getaffinity(0))
+        except AttributeError:
+            total_cpus = _os.cpu_count() or 4
+        n_threads = max(1, total_cpus // _MAX_W)
+        omp_env = _os.environ.copy()
+        omp_env["OMP_NUM_THREADS"] = str(n_threads)
+
+        master_fd, slave_fd = pty.openpty()
+        proc = subprocess.Popen(
+            cmd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            stdin=subprocess.DEVNULL,
+            cwd=str(self.work_dir),
+            env=omp_env,
+            start_new_session=True,
+            close_fds=True,
+        )
+        os.close(slave_fd)
+
+        def _kill_proc():
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+        last_progress = progress_start
+        deadline = time.time() + ROAST_TIMEOUT_SECONDS
+        STALL_TIMEOUT = 1800
+        CANCEL_POLL   = 5
+
+        last_stdout_time = time.time()
+        last_roast_error: str | None = None
+        convergence_failed = False
+        _buf = b""
+
+        while True:
+            try:
+                ready, _, _ = select.select([master_fd], [], [], CANCEL_POLL)
+            except (ValueError, OSError):
+                break
+
+            if not ready:
+                if redis_client.get(f"cancel:{self.session_id}"):
+                    _kill_proc()
+                    raise RuntimeError("Job cancelled by user")
+                if time.time() - last_stdout_time > STALL_TIMEOUT:
+                    _kill_proc()
+                    raise TimeoutError(f"ROAST stalled: no stdout for {STALL_TIMEOUT // 60} min")
+                if time.time() > deadline:
+                    _kill_proc()
+                    raise TimeoutError(f"ROAST timed out after {ROAST_TIMEOUT_SECONDS}s")
+                continue
+
+            try:
+                chunk = os.read(master_fd, 4096)
+            except OSError:
+                break
+
+            if not chunk:
+                break
+
+            last_stdout_time = time.time()
+            _buf += chunk
+
+            while b"\n" in _buf:
+                raw_line, _buf = _buf.split(b"\n", 1)
+                line = raw_line.decode("utf-8", errors="replace").strip("\r")
+                if not line:
+                    continue
+
+                session_log(self.session_id, f"[ROAST stdout] {line}")
+
+                ll = line.lower()
+                if "cfg_mlbatch_appcfg_master" in line or ("Unrecognized function" in line and "cfg_" in line):
+                    last_roast_error = "SPM segmentation step failed — compiled MATLAB cannot run SPM's batch system."
+                elif "was not meshed properly" in line:
+                    last_roast_error = line.strip()
+                    convergence_failed = True
+                elif "convergence not reached" in ll or ("maximum number of iterations" in ll and "reached" in ll):
+                    last_roast_error = "FEM solver failed to converge."
+                    convergence_failed = True
+                elif "matrix is singular" in ll or ("singular" in ll and "working precision" in ll):
+                    last_roast_error = "FEM solver hit a singular matrix."
+                    convergence_failed = True
+                elif "nan" in ll and ("solution" in ll or "residual" in ll or "result" in ll):
+                    last_roast_error = "FEM solution contains NaN — solver diverged."
+                    convergence_failed = True
+                elif "error in roast>runfem" in ll or "getdp returned" in ll:
+                    last_roast_error = f"FEM solver error: {line.strip()}"
+                    convergence_failed = True
+                elif "Error using" in line or "Unrecognized function or variable" in line:
+                    last_roast_error = line.strip()
+
+                if redis_client.get(f"cancel:{self.session_id}"):
+                    _kill_proc()
+                    raise RuntimeError("Job cancelled by user")
+
+                matched = False
+                for substring, event_name, pct in STEP_MAP:
+                    if substring in line:
+                        if pct > last_progress:
+                            self._emit(event_name, pct)
+                            last_progress = pct
+                        matched = True
+                        break
+
+                if not matched:
+                    for pattern, lo, hi, event_name in _GETDP_RANGES:
+                        m = pattern.search(line)
+                        if m:
+                            raw_pct = int(m.group(1))
+                            mapped = lo + int((raw_pct / 100.0) * (hi - lo))
+                            if mapped > last_progress:
+                                self._emit(event_name, mapped)
+                                last_progress = mapped
+                            break
+
+            if time.time() > deadline:
+                _kill_proc()
+                raise TimeoutError(f"ROAST timed out after {ROAST_TIMEOUT_SECONDS}s")
+
+        try:
+            os.close(master_fd)
+        except OSError:
+            pass
+
+        _chmod_stop.set()
+        proc.wait()
+
+        if proc.returncode != 0:
+            error = last_roast_error or (
+                f"ROAST exited with code {proc.returncode} — check session logs."
+            )
+            return convergence_failed, error, last_progress
+
+        return False, None, last_progress
+
+    # ------------------------------------------------------------------
+    def _clean_roast_intermediates(self):
+        """Delete ROAST-generated mesh/FEM files so a retry starts fresh."""
+        patterns = ["*.msh", "sim_*", "*.msh.mat"]
+        for pattern in patterns:
+            for p in self.work_dir.glob(pattern):
+                try:
+                    if p.is_dir():
+                        shutil.rmtree(p)
+                    else:
+                        p.unlink()
+                except OSError:
+                    pass
+        session_log(self.session_id, "[ROAST] Cleaned intermediate files for retry")
+
+    # ------------------------------------------------------------------
+    def _escalate_mesh(self):
+        """Switch to standard mesh quality for the retry attempt."""
+        current_quality = self.payload.get("quality", "standard")
+        if current_quality == "fast":
+            # Fast → standard: use the full-resolution default mesh options
+            self.payload = {**self.payload, "quality": "standard", "mesh_options": None}
+            session_log(self.session_id, "[ROAST] Mesh escalated: fast → standard")
+        else:
+            # Already standard — tighten mesh by reducing maxvol
+            current_opts = self.payload.get("mesh_options") or DEFAULT_MESH_OPTIONS.copy()
+            tighter = {**current_opts, "maxvol": max(5, current_opts.get("maxvol", 10) // 2)}
+            self.payload = {**self.payload, "mesh_options": tighter}
+            session_log(self.session_id, f"[ROAST] Mesh escalated: maxvol → {tighter['maxvol']}")
+
+    # ------------------------------------------------------------------
     def run(self):
         """
         Full ROAST pipeline: prepare → write config → launch binary → stream progress.
+        Automatically retries once with a refined mesh on FEM/meshing failures.
         """
         try:
             set_roast_status(self.session_id, "running", self.model_name)
@@ -306,193 +510,28 @@ class ROASTRunner:
             t1_path = self.prepare_working_directory()
             self._emit("roast_prepare", 5)
 
-            config_path = self.write_config(t1_path)
-            cmd = self.build_command(config_path)
+            for attempt in range(2):  # at most one automatic retry
+                config_path = self.write_config(t1_path)
+                cmd = self.build_command(config_path)
+                session_log(self.session_id, f"[ROAST] Launching (attempt {attempt + 1}): {' '.join(cmd)}")
 
-            session_log(self.session_id, f"[ROAST] Launching: {' '.join(cmd)}")
-
-            # MCR extracts CTF archive binaries lazily (on first use) without
-            # execute bits. A one-shot chmod before launch misses files extracted
-            # mid-run (e.g. cgalmesh at Step 4). Run chmod in a background thread
-            # every 3 s for the duration of the process.
-            # Use $HOME env var — MCR cache lives under the user's home, which
-            # may differ from Path.home() when the container runs as root.
-            import threading as _threading
-            _home = Path(os.environ.get("HOME", str(Path.home())))
-            mcr_cache = _home / ".MathWorks" / "MatlabRuntimeCache"
-
-            def _chmod_mcr(stop_evt: "_threading.Event"):
-                while not stop_evt.is_set():
-                    if mcr_cache.exists():
-                        for _p in mcr_cache.rglob("*.mexa64"):
-                            try:
-                                _p.chmod(_p.stat().st_mode | 0o111)
-                            except OSError:
-                                pass
-                        for _p in mcr_cache.rglob("*"):
-                            if _p.is_file() and not _p.suffix:
-                                try:
-                                    _p.chmod(_p.stat().st_mode | 0o111)
-                                except OSError:
-                                    pass
-                    stop_evt.wait(timeout=0.5)
-
-            _chmod_stop = _threading.Event()
-            _chmod_thread = _threading.Thread(
-                target=_chmod_mcr, args=(_chmod_stop,), daemon=True
-            )
-            _chmod_thread.start()
-
-            # Use all cores visible to this process (respects Docker --cpuset / --cpus limits).
-            # os.cpu_count() returns the physical host count; sched_getaffinity(0) returns
-            # the cores actually allocated to this container.
-            import os as _os
-            from config import ROAST_MAX_WORKERS as _MAX_W
-            try:
-                total_cpus = len(_os.sched_getaffinity(0))
-            except AttributeError:
-                total_cpus = _os.cpu_count() or 4
-            # Divide CPUs evenly across concurrent ROAST workers so jobs
-            # don't all try to use every core simultaneously.
-            n_threads = max(1, total_cpus // _MAX_W)
-            omp_env = _os.environ.copy()
-            omp_env["OMP_NUM_THREADS"] = str(n_threads)
-
-            # Use a pseudo-terminal so MCR sees a TTY on stdout and uses
-            # line-buffering instead of 8 KB block-buffering.  stdbuf / PYTHONUNBUFFERED
-            # cannot override MCR's internal C++/Java I/O layer, but isatty() can.
-            master_fd, slave_fd = pty.openpty()
-
-            proc = subprocess.Popen(
-                cmd,
-                stdout=slave_fd,
-                stderr=slave_fd,
-                stdin=subprocess.DEVNULL,
-                cwd=str(self.work_dir),
-                env=omp_env,
-                start_new_session=True,  # own process group → killpg kills entire tree
-                close_fds=True,
-            )
-            os.close(slave_fd)  # parent keeps only the master end
-
-            def _kill_proc():
-                """Kill the entire process group (xvfb-run + run_roast_run.sh + roast_run)."""
-                try:
-                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-                except ProcessLookupError:
-                    pass
-
-            last_progress = 5
-            deadline = time.time() + ROAST_TIMEOUT_SECONDS
-            STALL_TIMEOUT = 1800   # declare stall if no stdout for 30 min
-            CANCEL_POLL  = 5       # check cancellation every 5 s during silence
-
-            last_stdout_time = time.time()
-            last_roast_error: str | None = None  # capture last MATLAB error line
-            _buf = b""
-
-            while True:
-                try:
-                    ready, _, _ = select.select([master_fd], [], [], CANCEL_POLL)
-                except (ValueError, OSError):
-                    break  # master_fd closed after child exits
-
-                if not ready:
-                    # No stdout in CANCEL_POLL seconds — check cancel / stall
-                    if redis_client.get(f"cancel:{self.session_id}"):
-                        _kill_proc()
-                        raise RuntimeError("Job cancelled by user")
-                    if time.time() - last_stdout_time > STALL_TIMEOUT:
-                        _kill_proc()
-                        raise TimeoutError(
-                            f"ROAST stalled: no stdout for {STALL_TIMEOUT // 60} min"
-                        )
-                    if time.time() > deadline:
-                        _kill_proc()
-                        raise TimeoutError(
-                            f"ROAST timed out after {ROAST_TIMEOUT_SECONDS}s"
-                        )
-                    continue
-
-                try:
-                    chunk = os.read(master_fd, 4096)
-                except OSError:
-                    break  # EIO — child process exited, slave side closed
-
-                if not chunk:
-                    break
-
-                last_stdout_time = time.time()
-                _buf += chunk
-
-                # Flush complete lines — match progress events inside this loop
-                while b"\n" in _buf:
-                    raw_line, _buf = _buf.split(b"\n", 1)
-                    line = raw_line.decode("utf-8", errors="replace").strip("\r")
-                    if not line:
-                        continue
-
-                    session_log(self.session_id, f"[ROAST stdout] {line}")
-
-                    # Capture MATLAB error lines so we can surface them if ROAST exits non-zero.
-                    # Map known patterns to friendly messages; fall back to the raw line.
-                    if "cfg_mlbatch_appcfg_master" in line or ("Unrecognized function" in line and "cfg_" in line):
-                        last_roast_error = "SPM segmentation step failed — compiled MATLAB cannot run SPM's batch system. The c1 bypass file may not have been detected."
-                    elif "was not meshed properly" in line:
-                        last_roast_error = f"Electrode meshing failed: {line.strip()} — try switching to Standard quality mesh."
-                    elif "Error using" in line or "Unrecognized function or variable" in line:
-                        last_roast_error = line.strip()
-
-                    # Check cancellation on each line
-                    if redis_client.get(f"cancel:{self.session_id}"):
-                        _kill_proc()
-                        raise RuntimeError("Job cancelled by user")
-
-                    # 1) Match fixed step substrings
-                    matched = False
-                    for substring, event_name, pct in STEP_MAP:
-                        if substring in line:
-                            if pct > last_progress:
-                                self._emit(event_name, pct)
-                                last_progress = pct
-                            matched = True
-                            break
-
-                    # 2) If no fixed match, try getDP percentage patterns (Step 5)
-                    if not matched:
-                        for pattern, lo, hi, event_name in _GETDP_RANGES:
-                            m = pattern.search(line)
-                            if m:
-                                raw_pct = int(m.group(1))
-                                mapped = lo + int((raw_pct / 100.0) * (hi - lo))
-                                if mapped > last_progress:
-                                    self._emit(event_name, mapped)
-                                    last_progress = mapped
-                                break
-
-                if time.time() > deadline:
-                    _kill_proc()
-                    raise TimeoutError(
-                        f"ROAST timed out after {ROAST_TIMEOUT_SECONDS}s"
-                    )
-
-            try:
-                os.close(master_fd)
-            except OSError:
-                pass
-
-            _chmod_stop.set()
-            proc.wait()
-
-            if proc.returncode != 0:
-                msg = last_roast_error or (
-                    "ROAST failed unexpectedly — check the session logs for the full MATLAB output. "
-                    f"(exit code {proc.returncode})"
+                convergence_failed, error, last_progress = self._run_subprocess(
+                    cmd, progress_start=5 if attempt == 0 else 10
                 )
-                raise RuntimeError(msg)
+
+                if error and convergence_failed and attempt == 0:
+                    session_log(self.session_id, f"[ROAST] Retryable failure: {error}. Escalating mesh.")
+                    self._emit("roast_retry", last_progress,
+                               detail=f"{error} — retrying with refined mesh…")
+                    self._clean_roast_intermediates()
+                    self._escalate_mesh()
+                    continue  # retry
+
+                if error:
+                    raise RuntimeError(error)
+                break  # success
 
             self.collect_outputs()
-
             set_roast_status(self.session_id, "complete", self.model_name)
             self._emit("roast_complete", 100)
             session_log(self.session_id, "[ROAST] Completed successfully")

--- a/ui_v2/app/components/viewer/RoastViewer.tsx
+++ b/ui_v2/app/components/viewer/RoastViewer.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback, useId, useMemo } from "react";
 import { Niivue, cmapper } from "@niivue/niivue";
-import { AlertTriangle, Eye, Palette } from "lucide-react";
+import { AlertTriangle, Eye, Palette, Info, ZoomIn } from "lucide-react";
 import { getSimulationResult, getSimNIBSResult } from "@/lib/api";
 import { COLORMAPS } from "./ViewerControls";
 import type { ColormapId } from "./ViewerControls";
@@ -10,8 +10,22 @@ import { cn } from "@/lib/utils";
 
 // Two fixed panels — primary ROAST scalar outputs (2D only)
 const PANELS = [
-  { type: "emag",    label: "E-field Magnitude", unit: "V/m", description: "Electric field intensity in tissue" },
-  { type: "voltage", label: "Voltage",           unit: "mV",  description: "Electric potential distribution" },
+  {
+    type: "emag",
+    label: "E-field Magnitude",
+    unit: "V/m",
+    description: "Electric field intensity in tissue",
+    recommended: true,
+    note: null,
+  },
+  {
+    type: "voltage",
+    label: "Voltage",
+    unit: "mV",
+    description: "Electric potential distribution",
+    recommended: false,
+    note: "Voltage appears nearly uniform inside brain tissue — the skull (high resistance) absorbs most of the potential drop. Use E-field Magnitude above to assess stimulation strength in the brain.",
+  },
 ] as const;
 
 type OutputType = typeof PANELS[number]["type"];
@@ -37,6 +51,8 @@ export default function RoastViewer({ inputUrl, sessionId, modelName, solver = "
   const [loading, setLoading]               = useState(false);
   const [loadErrors, setLoadErrors]         = useState<Partial<Record<OutputType, string>>>({});
   const [calRanges, setCalRanges]           = useState<Partial<Record<OutputType, { min: number; max: number }>>>({});
+  // When true, voltage colormap is clipped to the 5–99th percentile to reveal brain-tissue variation
+  const [voltageZoomed, setVoltageZoomed]   = useState(false);
 
   const colormapDropRef = useRef<HTMLDivElement>(null);
   const bufferCache     = useRef<Partial<Record<OutputType, ArrayBuffer>>>({});
@@ -186,6 +202,41 @@ export default function RoastViewer({ inputUrl, sessionId, modelName, solver = "
     });
   }, [colormap, initialized]);
 
+  // Apply / remove brain-range zoom on the voltage panel (index 1 = voltage)
+  const voltageNv = nvRefs.current[1];
+  useEffect(() => {
+    if (!initialized || !voltageNv || voltageNv.volumes.length < 2) return;
+    const vol = voltageNv.volumes[1];
+    const fullRange = calRanges["voltage"];
+    if (!fullRange) return;
+
+    if (voltageZoomed) {
+      // Compute 5th–99th percentile of non-zero voxels to reveal brain variation
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const img = (vol as any).img as Float32Array | undefined;
+      if (img) {
+        const nonzero = Array.from(img).filter((v: number) => v > 0).sort((a: number, b: number) => a - b);
+        if (nonzero.length > 0) {
+          const p05 = nonzero[Math.floor(nonzero.length * 0.05)];
+          const p99 = nonzero[Math.floor(nonzero.length * 0.99)];
+          vol.cal_min = p05;
+          vol.cal_max = p99;
+          setCalRanges(prev => ({ ...prev, voltage: { min: p05, max: p99 } }));
+        }
+      }
+    } else {
+      // Restore full range
+      vol.cal_min = fullRange.min > 0 ? fullRange.max * 0.01 : fullRange.min;
+      vol.cal_max = fullRange.max;
+      setCalRanges(prev => ({ ...prev, voltage: { min: 0, max: fullRange.max } }));
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (vol as any).colormapType = 1;
+    voltageNv.updateGLVolume();
+    voltageNv.drawScene();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [voltageZoomed, initialized]);
+
   const currentColormap = COLORMAPS.find(c => c.id === colormap) ?? COLORMAPS[0];
 
   // Build a CSS linear-gradient string from a Niivue colormap LUT
@@ -301,13 +352,40 @@ export default function RoastViewer({ inputUrl, sessionId, modelName, solver = "
         {PANELS.map((panel, i) => (
           <article key={panel.type} className="flex flex-col rounded-xl border border-border bg-surface overflow-hidden">
             <header className="border-b border-border px-4 py-3 flex items-center justify-between">
-              <div>
-                <h3 className="text-sm font-semibold text-foreground">{panel.label}</h3>
-                <p className="text-xs text-foreground-muted mt-0.5">{panel.description}</p>
+              <div className="flex items-center gap-2.5 flex-1 min-w-0">
+                <div>
+                  <div className="flex items-center gap-2">
+                    <h3 className="text-sm font-semibold text-foreground">{panel.label}</h3>
+                    {panel.recommended && (
+                      <span className="rounded-full bg-accent/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent">
+                        Recommended
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-xs text-foreground-muted mt-0.5">{panel.description}</p>
+                </div>
               </div>
-              <span className="text-xs font-mono text-foreground-muted bg-border/50 px-2 py-0.5 rounded">
-                {panel.unit}
-              </span>
+              <div className="flex items-center gap-2 shrink-0">
+                {panel.type === "voltage" && initialized && !loadErrors[panel.type] && (
+                  <button
+                    type="button"
+                    onClick={() => setVoltageZoomed(v => !v)}
+                    title={voltageZoomed ? "Reset to full range" : "Zoom colormap to brain-tissue range"}
+                    className={cn(
+                      "flex items-center gap-1 rounded-lg border px-2 py-1 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring",
+                      voltageZoomed
+                        ? "border-accent bg-accent/10 text-accent"
+                        : "border-border bg-background text-foreground-muted hover:border-accent/40 hover:text-foreground",
+                    )}
+                  >
+                    <ZoomIn className="h-3 w-3" aria-hidden="true" />
+                    {voltageZoomed ? "Zoomed" : "Zoom to brain"}
+                  </button>
+                )}
+                <span className="text-xs font-mono text-foreground-muted bg-border/50 px-2 py-0.5 rounded">
+                  {panel.unit}
+                </span>
+              </div>
             </header>
 
             {initialized && loadErrors[panel.type] ? (
@@ -339,7 +417,7 @@ export default function RoastViewer({ inputUrl, sessionId, modelName, solver = "
 
             {/* Scalar colorbar */}
             {initialized && !loadErrors[panel.type] && (
-              <div className="px-4 py-3 border-t border-border bg-surface">
+              <div className="px-4 py-3 border-t border-border bg-surface space-y-2.5">
                 <div className="flex items-center gap-3">
                   <span className="w-10 text-right text-xs font-mono text-foreground-muted tabular-nums">
                     {calRanges[panel.type] ? calRanges[panel.type]!.min.toFixed(2) : "0.00"}
@@ -355,6 +433,12 @@ export default function RoastViewer({ inputUrl, sessionId, modelName, solver = "
                       : `— ${panel.unit}`}
                   </span>
                 </div>
+                {panel.note && (
+                  <div className="flex items-start gap-2 rounded-lg border border-border/60 bg-background px-3 py-2">
+                    <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-foreground-muted" aria-hidden="true" />
+                    <p className="text-[11px] leading-snug text-foreground-muted">{panel.note}</p>
+                  </div>
+                )}
               </div>
             )}
           </article>


### PR DESCRIPTION
roast_runner.py:
- Extract subprocess loop into _run_subprocess() returning (convergence_failed, error, last_progress)
- Detect retryable failures: electrode meshing, FEM convergence, singular matrix, NaN solution
- Auto-retry once with escalated mesh (fast→standard, or halve maxvol if already standard)
- _clean_roast_intermediates() removes .msh/sim_ files before retry
- _escalate_mesh() bumps mesh quality for the retry attempt

RoastViewer.tsx:
- Mark E-field Magnitude panel with Recommended badge
- Add physics explanation note under voltage colorbar
- Add Zoom to brain toggle that clips voltage colormap to 5-99th percentile of non-zero voxels