### PR TITLE
feat(tes): add electrode mask viewer, back-nav fix, and running sim banner

### DIFF
--- a/api_v2/app.py
+++ b/api_v2/app.py
@@ -300,8 +300,8 @@ async def simulate(body: dict = Body(...)):
 # ============================================================
 @app.get("/simulate/results/{session_id}/{model_name}/{output_type}")
 async def get_simulate_result(session_id: str, model_name: str, output_type: str):
-    if output_type not in ("voltage", "efield", "emag"):
-        raise HTTPException(status_code=400, detail="output_type must be one of: voltage, efield, emag")
+    if output_type not in ("voltage", "efield", "emag", "mask_elec", "mask_gel"):
+        raise HTTPException(status_code=400, detail="output_type must be one of: voltage, efield, emag, mask_elec, mask_gel")
 
     # Read simulation tag from the saved config.json so we use the correct filename
     # regardless of which tag was used (hash-based since v2, "tDCSLAB" in older runs).

--- a/api_v2/runtime/session.py
+++ b/api_v2/runtime/session.py
@@ -45,6 +45,13 @@ def roast_working_dir(session_id: str, model_name: str = "") -> Path:
 
 
 def roast_output_path(session_id: str, output_type: str, model_name: str = "", simulation_tag: str = "tDCSLAB") -> Path:
+    work_dir = roast_working_dir(session_id, model_name)
+    if output_type == "mask_elec":
+        matches = list(work_dir.glob("T1_sim_*_mask_elec.nii"))
+        return matches[0] if matches else work_dir / "_missing_mask_elec.nii"
+    if output_type == "mask_gel":
+        matches = list(work_dir.glob("T1_sim_*_mask_gel.nii"))
+        return matches[0] if matches else work_dir / "_missing_mask_gel.nii"
     filenames = {
         "voltage": f"T1_{simulation_tag}_v.nii",
         "efield":  f"T1_{simulation_tag}_e.nii",
@@ -52,7 +59,7 @@ def roast_output_path(session_id: str, output_type: str, model_name: str = "", s
     }
     if output_type not in filenames:
         raise ValueError(f"Unknown ROAST output type: {output_type}")
-    return roast_working_dir(session_id, model_name) / filenames[output_type]
+    return work_dir / filenames[output_type]
 
 
 # -----------------------------------------------------------

--- a/ui_v2/app/components/LeaveGuardModal.tsx
+++ b/ui_v2/app/components/LeaveGuardModal.tsx
@@ -128,6 +128,17 @@ export default function LeaveGuardModal({
                 </button>
 
                 <button
+                  onClick={onLeave}
+                  className="flex w-full items-center gap-3 rounded-xl border border-border px-4 py-3 text-left transition-all hover:bg-surface-elevated focus:outline-none focus:ring-2 focus:ring-ring"
+                >
+                  <ArrowLeft className="h-4 w-4 text-foreground-muted shrink-0" />
+                  <div>
+                    <div className="text-sm font-medium text-foreground">Go back, keep simulation running</div>
+                    <div className="text-xs text-foreground-muted">Your results stay on the server for 24 hours</div>
+                  </div>
+                </button>
+
+                <button
                   onClick={() => setStep("delete_confirm")}
                   className="flex w-full items-center gap-3 rounded-xl border border-border px-4 py-3 text-left transition-all hover:bg-surface-elevated focus:outline-none focus:ring-2 focus:ring-ring"
                 >

--- a/ui_v2/app/components/viewer/RoastViewer.tsx
+++ b/ui_v2/app/components/viewer/RoastViewer.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback, useId, useMemo } from "react";
 import { Niivue, cmapper } from "@niivue/niivue";
-import { AlertTriangle, Eye, Palette, Info, ZoomIn } from "lucide-react";
+import { AlertTriangle, Eye, Palette, Info, ZoomIn, MapPin } from "lucide-react";
 import { getSimulationResult, getSimNIBSResult, type SimNIBSOutputType } from "@/lib/api";
 import { COLORMAPS } from "./ViewerControls";
 import type { ColormapId } from "./ViewerControls";
@@ -53,6 +53,12 @@ export default function RoastViewer({ inputUrl, sessionId, modelName, solver = "
   const [calRanges, setCalRanges]           = useState<Partial<Record<OutputType, { min: number; max: number }>>>({});
   // When true, voltage colormap is clipped to the 5–99th percentile to reveal brain-tissue variation
   const [voltageZoomed, setVoltageZoomed]   = useState(false);
+
+  // Electrode placement panel (ROAST only)
+  const canvasElecRef   = useRef<HTMLCanvasElement>(null);
+  const nvElecRef       = useRef<Niivue | null>(null);
+  const [elecReady, setElecReady]           = useState(false);
+  const [elecError, setElecError]           = useState(false);
 
   const colormapDropRef = useRef<HTMLDivElement>(null);
   const bufferCache     = useRef<Partial<Record<OutputType, ArrayBuffer>>>({});
@@ -185,6 +191,84 @@ export default function RoastViewer({ inputUrl, sessionId, modelName, solver = "
     return () => { mounted = false; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inputUrl, initialized]);
+
+  // Electrode placement viewer (ROAST only) — runs once after main viewers init
+  useEffect(() => {
+    if (!initialized || solver === "simnibs" || nvElecRef.current || !canvasElecRef.current) return;
+    let mounted = true;
+
+    const initElec = async () => {
+      const nv = new Niivue({
+        show3Dcrosshair: true,
+        isRadiologicalConvention: true,
+        backColor:      [0, 0, 0, 1] as [number, number, number, number],
+        crosshairColor: [1, 0, 0, 1] as [number, number, number, number],
+      });
+      nv.attachToCanvas(canvasElecRef.current!);
+      nvElecRef.current = nv;
+
+      // Load T1 base
+      const resp = await fetch(inputUrl);
+      if (!resp.ok || !mounted) return;
+      const inputBuf = await resp.arrayBuffer();
+      await nv.loadFromArrayBuffer(inputBuf.slice(0), "input.nii.gz");
+      nv.setOpacity(0, 1.0);
+      nv.setSliceType(nv.sliceTypeMultiplanar);
+
+      // Sync crosshair / scroll with the main panels
+      const mainNvs = nvRefs.current.filter(Boolean) as Niivue[];
+      mainNvs.forEach(m => m.broadcastTo([...mainNvs.filter(x => x !== m), nv], { "2d": true, "3d": false }));
+      nv.broadcastTo(mainNvs, { "2d": true, "3d": false });
+
+      // Fetch both mask buffers
+      const fetchMask = async (type: "mask_elec" | "mask_gel"): Promise<ArrayBuffer | null> => {
+        try {
+          const blob = await getSimulationResult(sessionId, modelName, type);
+          const buf = await blob.arrayBuffer();
+          return buf.byteLength > 0 ? buf : null;
+        } catch { return null; }
+      };
+
+      const [elecBuf, gelBuf] = await Promise.all([fetchMask("mask_elec"), fetchMask("mask_gel")]);
+      if (!mounted) return;
+
+      if (!elecBuf && !gelBuf) { setElecError(true); return; }
+
+      if (elecBuf) {
+        await nv.loadFromArrayBuffer(elecBuf.slice(0), "mask_elec.nii");
+        if (nv.volumes.length >= 2) {
+          const vol = nv.volumes[1];
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (vol as any).colormapType = 1;
+          vol.cal_min = 0.5;
+          vol.cal_max = 1.0;
+          nv.setColormap(vol.id, "hot");
+          nv.setOpacity(1, 0.85);
+        }
+      }
+
+      if (gelBuf) {
+        await nv.loadFromArrayBuffer(gelBuf.slice(0), "mask_gel.nii");
+        const gelIdx = nv.volumes.length - 1;
+        if (gelIdx >= 2) {
+          const vol = nv.volumes[gelIdx];
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (vol as any).colormapType = 1;
+          vol.cal_min = 0.5;
+          vol.cal_max = 1.0;
+          nv.setColormap(vol.id, "winter");
+          nv.setOpacity(gelIdx, 0.65);
+        }
+      }
+
+      nv.drawScene();
+      if (mounted) setElecReady(true);
+    };
+
+    initElec().catch(() => { if (mounted) setElecError(true); });
+    return () => { mounted = false; };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialized, inputUrl, sessionId, modelName, solver]);
 
   // Sync opacity
   useEffect(() => {
@@ -449,6 +533,64 @@ export default function RoastViewer({ inputUrl, sessionId, modelName, solver = "
             )}
           </article>
         ))}
+
+        {/* Electrode placement panel — ROAST only */}
+        {solver !== "simnibs" && (
+        <article className="flex flex-col rounded-xl border border-border bg-surface overflow-hidden">
+          <header className="border-b border-border px-4 py-3 flex items-center justify-between">
+            <div className="flex items-center gap-2.5">
+              <MapPin className="h-4 w-4 text-accent" aria-hidden="true" />
+              <div>
+                <div className="flex items-center gap-2">
+                  <h3 className="text-sm font-semibold text-foreground">Electrode Placement</h3>
+                </div>
+                <p className="text-xs text-foreground-muted mt-0.5">
+                  <span className="inline-flex items-center gap-1">
+                    <span className="inline-block h-2 w-2 rounded-sm bg-[#ff6000]" />
+                    Electrode rubber
+                  </span>
+                  <span className="mx-2">·</span>
+                  <span className="inline-flex items-center gap-1">
+                    <span className="inline-block h-2 w-2 rounded-sm bg-[#0080ff]" />
+                    Gel layer
+                  </span>
+                </p>
+              </div>
+            </div>
+            {!elecReady && !elecError && (
+              <div className="flex items-center gap-2 text-xs text-foreground-muted">
+                <div className="h-3 w-3 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+                Loading…
+              </div>
+            )}
+          </header>
+
+          {elecError ? (
+            <div className="flex items-center gap-3 px-4 py-5 text-foreground-muted">
+              <AlertTriangle className="h-4 w-4 shrink-0 text-foreground-muted/60" />
+              <p className="text-sm">Electrode mask files not found — run the simulation to generate placement data.</p>
+            </div>
+          ) : (
+            <div className="relative bg-black" style={{ height: "500px" }}>
+              <canvas
+                ref={canvasElecRef}
+                width={512}
+                height={512}
+                style={{ width: "100%", height: "100%" }}
+                aria-label="Electrode placement viewer"
+              />
+              {!elecReady && (
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <div className="flex flex-col items-center gap-2">
+                    <div className="h-8 w-8 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+                    <span className="text-sm text-foreground-muted">Loading electrode masks…</span>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </article>
+        )}
       </div>
 
       <p className="text-xs text-foreground-muted">

--- a/ui_v2/app/components/wizard/steps/ResultsStep.tsx
+++ b/ui_v2/app/components/wizard/steps/ResultsStep.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Download, RefreshCw, Check, AlertTriangle, Zap, ArrowRight, Trash2, X } from "lucide-react";
 import Link from "next/link";
 import { useJob } from "@/context/JobContext";
@@ -8,10 +8,23 @@ import { Button } from "@/components/ui/button";
 import SplitViewer from "../../viewer/SplitViewer";
 import { API_BASE, deleteSession } from "@/lib/api";
 
+const ACTIVE_SIM_KEY = "grace_active_sim";
+type SavedSim = { sessionId: string; model: string; solver: "roast" | "simnibs"; startedAt: number };
+
 export default function ResultsStep() {
   const { sessionId, models, inputBlobUrl, resetJob, selectedFile, error } = useJob();
   const [deleteConfirm, setDeleteConfirm] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [activeSim, setActiveSim] = useState<SavedSim | null>(null);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(ACTIVE_SIM_KEY);
+      if (!raw) return;
+      const s = JSON.parse(raw) as SavedSim;
+      if (Date.now() - s.startedAt < 4 * 3600 * 1000) setActiveSim(s);
+    } catch {}
+  }, []);
 
   const handleDeleteSession = async () => {
     if (!sessionId) return;
@@ -120,6 +133,27 @@ export default function ResultsStep() {
           </Button>
         </div>
       </div>
+
+      {/* Running tDCS simulation banner */}
+      {activeSim && (
+        <div className="flex items-center gap-4 rounded-xl border border-accent/40 bg-accent/5 px-4 py-3">
+          <div className="h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-foreground">
+              tDCS simulation running in background
+            </p>
+            <p className="text-xs text-foreground-muted truncate">
+              {activeSim.model.replace("-native", "").replace("-fs", "").toUpperCase()} · {activeSim.solver.toUpperCase()}
+            </p>
+          </div>
+          <Link
+            href="/tes"
+            className="shrink-0 rounded-lg bg-accent px-3 py-1.5 text-xs font-medium text-accent-foreground transition-colors hover:bg-accent/90"
+          >
+            View progress →
+          </Link>
+        </div>
+      )}
 
       {/* tDCS Simulation CTA */}
       <Link href="/tes" className="block group">

--- a/ui_v2/lib/api.ts
+++ b/ui_v2/lib/api.ts
@@ -243,7 +243,7 @@ export function connectROASTSSE(
 export async function getSimulationResult(
   sessionId: string,
   modelName: string,
-  outputType: "voltage" | "efield" | "emag"
+  outputType: "voltage" | "efield" | "emag" | "mask_elec" | "mask_gel"
 ): Promise<Blob> {
   const res = await fetch(`${API_BASE}/simulate/results/${sessionId}/${modelName}/${outputType}`);
   if (!res.ok) throw new Error(`Simulation result not found: ${outputType}`);


### PR DESCRIPTION


- RoastViewer: add Electrode Placement panel showing mask_elec (hot) and mask_gel (winter) overlays on T1, scroll-synced with E-field/voltage panels
- session.py / app.py / api.ts: support mask_elec and mask_gel output types via glob since the sim hash in the filename varies per run
- LeaveGuardModal: add "Go back, keep simulation running" option so users are not forced to email or delete before navigating away
- ResultsStep: show a pulsing banner when a tDCS sim is active in localStorage, with a direct link back to the TES page