### PR TITLE
feat(tes): seg_source support for ROAST and SimNIBS solvers

### DIFF
--- a/api_v2/app.py
+++ b/api_v2/app.py
@@ -376,6 +376,7 @@ async def simulate_simnibs(body: dict = Body(...)):
         "model_name": model_name,
         "recipe": recipe,
         "electrode_type": body.get("electrode_type"),
+        "seg_source": body.get("seg_source", "deep_learning"),
     }
 
     set_simnibs_status(session_id, "queued", model_name)

--- a/api_v2/runtime/roast_runner.py
+++ b/api_v2/runtime/roast_runner.py
@@ -291,11 +291,11 @@ class ROASTRunner:
 
         seg_source = self.payload.get("seg_source", "nn")
 
-        if seg_source == "spm":
-            # SPM mode: do NOT pre-write the mask or dummy c1 files.
+        if seg_source == "roast":
+            # ROAST segmentation mode: do NOT pre-write the mask or dummy c1 files.
             # roast_run.m will call run_spm_seg() to run the full SPM pipeline,
             # then ROAST's segTouchup (Step 2) will generate the masks file.
-            session_log(self.session_id, "[ROAST] SPM mode: skipping NN mask and c1 bypass — ROAST will run SPM segmentation")
+            session_log(self.session_id, "[ROAST] ROAST segmentation mode: skipping NN mask and c1 bypass — ROAST will run SPM segmentation")
         else:
             # NN mode: zero-pad the processed mask data, then save both mask files
             # (T1_T1orT2_masks.nii and T1_ras_T1orT2_masks.nii) in one pass.

--- a/api_v2/runtime/simnibs_runner.py
+++ b/api_v2/runtime/simnibs_runner.py
@@ -353,7 +353,7 @@ class SimNIBSRunner:
         return base_m2m
 
     # ------------------------------------------------------------------
-    def build_mesh(self, seg_path: Path) -> Path:
+    def build_mesh(self, seg_path: Path | None) -> Path:
         """
         Build a FEM mesh from the remapped segmentation labels.
 
@@ -388,15 +388,21 @@ class SimNIBSRunner:
             settings_file.write_text(content)
 
         # Step 4 — save custom labels into m2m for post-processing
+        # In "charm" mode, keep CHARM's own segmentation (don't overwrite with deep learning labels)
+        seg_source = self.payload.get("seg_source", "deep_learning")
         custom_tissues = model_m2m / "custom_tissues.nii.gz"
-        shutil.copy2(str(seg_path), str(custom_tissues))
-        session_log(self.session_id, f"[SimNIBS] Custom labels → {custom_tissues}")
+        if seg_source == "charm":
+            session_log(self.session_id, "[SimNIBS] CHARM segmentation mode: using CHARM's own tissue labels")
+        else:
+            shutil.copy2(str(seg_path), str(custom_tissues))
+            session_log(self.session_id, f"[SimNIBS] Custom labels → {custom_tissues}")
 
         # Step 5 — meshmesh
         custom_mesh = self.work_dir / f"{SUBJECT}_custom_mesh.msh"
         self._emit("simnibs_charm_mesh", 65)
         session_log(self.session_id, "[SimNIBS] meshmesh: building FEM mesh from custom labels…")
-        cmd      = _meshmesh_cmd() + [str(seg_path), str(custom_mesh), "--voxsize_meshing", "0.5"]
+        mesh_input = custom_tissues if seg_path is None else seg_path
+        cmd      = _meshmesh_cmd() + [str(mesh_input), str(custom_mesh), "--voxsize_meshing", "0.5"]
         deadline = time.time() + SIMNIBS_TIMEOUT_SECONDS
         self._run_proc(cmd, "meshmesh", self.work_dir, deadline)
 
@@ -542,8 +548,13 @@ class SimNIBSRunner:
             set_simnibs_status(self.session_id, "running", self.model_name)
             self._emit("simnibs_start", 2)
 
-            seg_path = self.prepare_segmentation()
-            self._emit("simnibs_seg_ready", 5)
+            seg_source = self.payload.get("seg_source", "deep_learning")
+            if seg_source == "charm":
+                seg_path = None
+                self._emit("simnibs_seg_ready", 5)
+            else:
+                seg_path = self.prepare_segmentation()
+                self._emit("simnibs_seg_ready", 5)
 
             mesh_path = self.build_mesh(seg_path)
             self.run_fem(mesh_path)

--- a/ui_v2/app/components/tes/TESPage.tsx
+++ b/ui_v2/app/components/tes/TESPage.tsx
@@ -216,7 +216,7 @@ export default function TESPage() {
   const [selectedModels, setSelectedModels]     = useState<string[]>([]);
   const [solver, setSolver]                     = useState<Solver>("roast");
   const [quality, setQuality]                   = useState<"fast" | "standard">("fast");
-  const [segSource, setSegSource]               = useState<"nn" | "spm">("nn");
+  const [segSource, setSegSource]               = useState<"nn" | "roast">("nn");
   const [electrodeConfig, setElectrodeConfig]   = useState<ElectrodeConfig>({
     anode: "F3", cathode: "F4", currentMa: 2, electrodeType: "pad",
   });
@@ -818,7 +818,7 @@ export default function TESPage() {
             <div>
               <SectionLabel>Segmentation Source</SectionLabel>
               <div className="flex gap-2">
-                {(["nn", "spm"] as const).map(src => (
+                {(["nn", "roast"] as const).map(src => (
                   <button
                     key={src}
                     type="button"
@@ -830,11 +830,11 @@ export default function TESPage() {
                         : "border-border bg-background text-foreground-muted hover:border-accent/30",
                     )}
                   >
-                    {src === "nn" ? "Neural Network" : "SPM"}
+                    {src === "nn" ? "Neural Network" : "ROAST"}
                   </button>
                 ))}
               </div>
-              {segSource === "spm" ? (
+              {segSource === "roast" ? (
                 <div className="mt-2 flex gap-2 rounded-lg border border-warning/40 bg-warning/5 px-3 py-2.5">
                   <Construction className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" />
                   <div className="space-y-0.5">

--- a/ui_v2/app/components/tes/TESWizard.tsx
+++ b/ui_v2/app/components/tes/TESWizard.tsx
@@ -170,6 +170,8 @@ export default function TESWizard({ sessionId, models, inputBlobUrl }: TESWizard
   const [selectedModels, setSelectedModels] = useState<string[]>([]);
   const [solver, setSolver]               = useState<Solver>("roast");
   const [quality, setQuality]             = useState<"fast" | "standard">("fast");
+  const [roastSegSource, setRoastSegSource]     = useState<"nn" | "roast">("nn");
+  const [simnibsSegSource, setSimnibsSegSource] = useState<"deep_learning" | "charm">("deep_learning");
   const [electrodeConfig, setElectrodeConfig] = useState<ElectrodeConfig>({
     anode: "F3", cathode: "F4", currentMa: 2, electrodeType: "pad",
   });
@@ -208,7 +210,7 @@ export default function TESWizard({ sessionId, models, inputBlobUrl }: TESWizard
       setRunState(key, { status: "running", progress: 2, step: "Starting..." });
 
       try {
-        await startSimulation(sessionId, next.model, quality, recipe, electype);
+        await startSimulation(sessionId, next.model, quality, recipe, electype, roastSegSource);
       } catch (e: unknown) {
         setRunState(key, { status: "error", error: (e as Error).message || "Failed to start ROAST" });
         runningRef.current = false;
@@ -247,7 +249,7 @@ export default function TESWizard({ sessionId, models, inputBlobUrl }: TESWizard
       setRunState(key, { status: "running", progress: 2, step: "Starting..." });
 
       try {
-        await startSimNIBSSimulation(sessionId, next.model, recipe, electype);
+        await startSimNIBSSimulation(sessionId, next.model, recipe, electype, simnibsSegSource);
       } catch (e: unknown) {
         setRunState(key, { status: "error", error: (e as Error).message || "Failed to start SimNIBS" });
         runningRef.current = false;
@@ -442,36 +444,59 @@ export default function TESWizard({ sessionId, models, inputBlobUrl }: TESWizard
       <ElectrodeConfigPanel config={electrodeConfig} onChange={setElectrodeConfig} />
 
       {(solver === "roast" || solver === "both") && (
-        <div className="rounded-xl border border-border bg-surface p-4 space-y-2">
-          <h3 className="font-mono text-[10px] font-bold uppercase tracking-widest text-accent">// ROAST Quality</h3>
-          <div className="flex rounded-lg border border-border overflow-hidden text-sm font-medium">
-            <button
-              type="button"
-              onClick={() => setQuality("fast")}
-              className={cn(
-                "flex-1 py-2 transition-colors",
-                quality === "fast" ? "bg-accent text-white" : "text-foreground-muted hover:bg-surface-elevated",
-              )}
-            >
-              ⚡ Fast (~10–15 min)
-            </button>
-            <button
-              type="button"
-              onClick={() => setQuality("standard")}
-              className={cn(
-                "flex-1 py-2 transition-colors",
-                quality === "standard" ? "bg-accent text-white" : "text-foreground-muted hover:bg-surface-elevated",
-              )}
-            >
-              🎯 Standard (~20–30 min)
-            </button>
+        <div className="rounded-xl border border-border bg-surface p-4 space-y-3">
+          <h3 className="font-mono text-[10px] font-bold uppercase tracking-widest text-accent">// ROAST Options</h3>
+          <div>
+            <p className="text-xs text-foreground-muted mb-1.5">Mesh quality</p>
+            <div className="flex rounded-lg border border-border overflow-hidden text-sm font-medium">
+              <button type="button" onClick={() => setQuality("fast")} className={cn("flex-1 py-2 transition-colors", quality === "fast" ? "bg-accent text-white" : "text-foreground-muted hover:bg-surface-elevated")}>
+                ⚡ Fast (~10–15 min)
+              </button>
+              <button type="button" onClick={() => setQuality("standard")} className={cn("flex-1 py-2 transition-colors", quality === "standard" ? "bg-accent text-white" : "text-foreground-muted hover:bg-surface-elevated")}>
+                🎯 Standard (~20–30 min)
+              </button>
+            </div>
+            <p className="text-xs text-foreground-muted mt-1">
+              {quality === "fast" ? "Coarser mesh, faster solve — good for exploration." : "Full mesh resolution — recommended for final results."}
+            </p>
           </div>
-          <p className="text-xs text-foreground-muted">
-            {quality === "fast" ? "Coarser mesh, faster solve — good for exploration." : "Full mesh resolution — recommended for final results."}
-          </p>
-          <p className="text-[11px] text-foreground-muted/60 mt-1">
+          <div>
+            <p className="text-xs text-foreground-muted mb-1.5">Segmentation source</p>
+            <div className="flex rounded-lg border border-border overflow-hidden text-sm font-medium">
+              <button type="button" onClick={() => setRoastSegSource("nn")} className={cn("flex-1 py-2 transition-colors", roastSegSource === "nn" ? "bg-accent text-white" : "text-foreground-muted hover:bg-surface-elevated")}>
+                Deep Learning
+              </button>
+              <button type="button" onClick={() => setRoastSegSource("roast")} className={cn("flex-1 py-2 transition-colors", roastSegSource === "roast" ? "bg-accent text-white" : "text-foreground-muted hover:bg-surface-elevated")}>
+                ROAST (SPM)
+              </button>
+            </div>
+            <p className="text-xs text-foreground-muted mt-1">
+              {roastSegSource === "nn" ? "Use GRACE/DOMINO/DOMINO++ segmentation (recommended)." : "Use ROAST's built-in SPM segmentation (slower, no model required)."}
+            </p>
+          </div>
+          <p className="text-[11px] text-foreground-muted/60">
             First run after deploy may take 3–5 min longer (runtime cache cold start).
           </p>
+        </div>
+      )}
+
+      {(solver === "simnibs" || solver === "both") && (
+        <div className="rounded-xl border border-border bg-surface p-4 space-y-3">
+          <h3 className="font-mono text-[10px] font-bold uppercase tracking-widest text-accent">// SimNIBS Options</h3>
+          <div>
+            <p className="text-xs text-foreground-muted mb-1.5">Segmentation source</p>
+            <div className="flex rounded-lg border border-border overflow-hidden text-sm font-medium">
+              <button type="button" onClick={() => setSimnibsSegSource("deep_learning")} className={cn("flex-1 py-2 transition-colors", simnibsSegSource === "deep_learning" ? "bg-accent text-white" : "text-foreground-muted hover:bg-surface-elevated")}>
+                Deep Learning
+              </button>
+              <button type="button" onClick={() => setSimnibsSegSource("charm")} className={cn("flex-1 py-2 transition-colors", simnibsSegSource === "charm" ? "bg-accent text-white" : "text-foreground-muted hover:bg-surface-elevated")}>
+                CHARM
+              </button>
+            </div>
+            <p className="text-xs text-foreground-muted mt-1">
+              {simnibsSegSource === "deep_learning" ? "Use GRACE/DOMINO/DOMINO++ segmentation (recommended)." : "Use SimNIBS CHARM segmentation (no model required, slower initialization)."}
+            </p>
+          </div>
         </div>
       )}
 

--- a/ui_v2/app/components/viewer/RoastViewer.tsx
+++ b/ui_v2/app/components/viewer/RoastViewer.tsx
@@ -8,8 +8,8 @@ import { COLORMAPS } from "./ViewerControls";
 import type { ColormapId } from "./ViewerControls";
 import { cn } from "@/lib/utils";
 
-// Two fixed panels — primary ROAST scalar outputs (2D only)
-const PANELS = [
+// Panel definitions — labels differ between ROAST and SimNIBS
+const ROAST_PANELS = [
   {
     type: "emag",
     label: "E-field Magnitude",
@@ -28,7 +28,26 @@ const PANELS = [
   },
 ] as const;
 
-type OutputType = typeof PANELS[number]["type"];
+const SIMNIBS_PANELS = [
+  {
+    type: "emag",
+    label: "Current Density (J)",
+    unit: "A/m²",
+    description: "Total current density magnitude across all tissues",
+    recommended: true,
+    note: null,
+  },
+  {
+    type: "voltage",
+    label: "Brain J (WM+GM)",
+    unit: "A/m²",
+    description: "Current density restricted to white and gray matter",
+    recommended: false,
+    note: "Masked to white matter and gray matter only — isolates the current delivered to cortical and subcortical tissue.",
+  },
+] as const;
+
+type OutputType = "emag" | "voltage";
 
 const OPACITY_PRESETS = [0, 0.25, 0.5, 0.75, 1] as const;
 
@@ -40,6 +59,7 @@ interface RoastViewerProps {
 }
 
 export default function RoastViewer({ inputUrl, sessionId, modelName, solver = "roast" }: RoastViewerProps) {
+  const PANELS = solver === "simnibs" ? SIMNIBS_PANELS : ROAST_PANELS;
   const canvasRefs = [useRef<HTMLCanvasElement>(null), useRef<HTMLCanvasElement>(null)];
   const nvRefs = useRef<(Niivue | null)[]>([null, null]);
 

--- a/ui_v2/lib/api.ts
+++ b/ui_v2/lib/api.ts
@@ -169,7 +169,7 @@ export async function startSimulation(
   quality: "fast" | "standard" = "standard",
   recipe?: (string | number)[],
   electrode_type?: string[],
-  segSource?: "nn" | "spm",
+  segSource?: "nn" | "roast",
 ): Promise<SimulateResponse> {
   const body: Record<string, unknown> = { session_id: sessionId, model_name: modelName, quality };
   if (recipe) body.recipe = recipe;
@@ -266,11 +266,13 @@ export async function startSimNIBSSimulation(
   sessionId: string,
   modelName: string,
   recipe?: (string | number)[],
-  electrode_type?: string[]
+  electrode_type?: string[],
+  segSource?: "deep_learning" | "charm",
 ): Promise<SimulateResponse> {
   const body: Record<string, unknown> = { session_id: sessionId, model_name: modelName };
   if (recipe) body.recipe = recipe;
   if (electrode_type) body.electrode_type = electrode_type;
+  if (segSource) body.seg_source = segSource;
 
   const res = await fetch(`${API_BASE}/simulate/simnibs`, {
     method: "POST",


### PR DESCRIPTION
- Rename spm -> roast seg_source in roast_runner, TESPage, api.ts
- Add charm seg_source to simnibs_runner: skips NN label remapping, uses CHARM's own segmentation output
- Add seg_source UI toggles in TESWizard for both ROAST and SimNIBS
- Split RoastViewer panels into ROAST_PANELS / SIMNIBS_PANELS with correct J-map labels for SimNIBS outputs
- Pass seg_source through app.py SimNIBS job payload