### PR TITLE
feat(tes): unique run_id sub-sessions for each simulation run

### DIFF
--- a/api_v2/app.py
+++ b/api_v2/app.py
@@ -268,6 +268,8 @@ async def simulate(body: dict = Body(...)):
     seg_source = body.get("seg_source", "nn")
     session_log(session_id, f"[ROAST] seg_source={seg_source} (SPM bypass not yet implemented — requires ROAST+SPM rebuild)")
 
+    run_id = uuid.uuid4().hex[:12]
+
     payload = {
         "model_name": model_name,
         "recipe": recipe,
@@ -278,6 +280,7 @@ async def simulate(body: dict = Body(...)):
         "simulation_tag": body.get("simulation_tag"),
         "quality": body.get("quality", "standard"),  # "fast" or "standard"
         "seg_source": seg_source,
+        "run_id": run_id,
     }
 
     # Flush stale SSE events from previous runs so the new stream doesn't
@@ -285,19 +288,20 @@ async def simulate(body: dict = Body(...)):
     from runtime.sse import redis_event_key
     redis_client.delete(redis_event_key(session_id))
 
-    set_roast_status(session_id, "queued", model_name)
+    set_roast_status(session_id, "queued", model_name, run_id)
     enqueue_roast_job(session_id, payload)
     recipe_log = " ".join(str(x) for x in (recipe or []))
-    session_log(session_id, f"ROAST job enqueued for model={model_name} recipe=[{recipe_log}] quality={payload['quality']}")
+    session_log(session_id, f"ROAST job enqueued for model={model_name} run_id={run_id} recipe=[{recipe_log}] quality={payload['quality']}")
 
     from runtime.sse import push_event
     push_event(session_id, {"event": "roast_queued", "progress": 0, "model": model_name})
 
-    return {"session_id": session_id, "status": "queued"}
+    return {"session_id": session_id, "status": "queued", "run_id": run_id}
 
 
 # ============================================================
 # GET /simulate/results/{session_id}/{model_name}/{output_type}
+# (legacy — no run_id; kept for backward compatibility)
 # ============================================================
 @app.get("/simulate/results/{session_id}/{model_name}/{output_type}")
 async def get_simulate_result(session_id: str, model_name: str, output_type: str):
@@ -323,6 +327,40 @@ async def get_simulate_result(session_id: str, model_name: str, output_type: str
 
     if not out_path.exists():
         raise HTTPException(status_code=404, detail=f"ROAST output '{output_type}' not found for model '{model_name}'. Run simulation first.")
+
+    return FileResponse(
+        path=str(out_path),
+        filename=f"{output_type}.nii",
+        media_type="application/octet-stream",
+    )
+
+
+# ============================================================
+# GET /simulate/results/{session_id}/{model_name}/{run_id}/{output_type}
+# (new — includes run_id so each electrode configuration is isolated)
+# ============================================================
+@app.get("/simulate/results/{session_id}/{model_name}/{run_id}/{output_type}")
+async def get_simulate_result_by_run(session_id: str, model_name: str, run_id: str, output_type: str):
+    if output_type not in ("voltage", "efield", "emag", "mask_elec", "mask_gel"):
+        raise HTTPException(status_code=400, detail="output_type must be one of: voltage, efield, emag, mask_elec, mask_gel")
+
+    import json as _json
+    from runtime.session import roast_working_dir as _roast_wd
+    sim_tag = "tDCSLAB"
+    config_path = _roast_wd(session_id, model_name, run_id) / "config.json"
+    if config_path.exists():
+        try:
+            sim_tag = _json.loads(config_path.read_text()).get("simulationtag", "tDCSLAB")
+        except Exception:
+            pass
+
+    try:
+        out_path = roast_output_path(session_id, output_type, model_name, sim_tag, run_id)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    if not out_path.exists():
+        raise HTTPException(status_code=404, detail=f"ROAST output '{output_type}' not found for model '{model_name}' run '{run_id}'. Run simulation first.")
 
     return FileResponse(
         path=str(out_path),
@@ -372,25 +410,28 @@ async def simulate_simnibs(body: dict = Body(...)):
         )
 
     recipe = body.get("recipe")
+    run_id = uuid.uuid4().hex[:12]
     payload = {
         "model_name": model_name,
         "recipe": recipe,
         "electrode_type": body.get("electrode_type"),
         "seg_source": body.get("seg_source", "deep_learning"),
+        "run_id": run_id,
     }
 
-    set_simnibs_status(session_id, "queued", model_name)
+    set_simnibs_status(session_id, "queued", model_name, run_id)
     enqueue_simnibs_job(session_id, payload)
-    session_log(session_id, f"[SimNIBS] Job enqueued for model={model_name}")
+    session_log(session_id, f"[SimNIBS] Job enqueued for model={model_name} run_id={run_id}")
 
     from runtime.sse import push_event
     push_event(session_id, {"event": "simnibs_queued", "progress": 0, "model": model_name})
 
-    return {"session_id": session_id, "status": "queued"}
+    return {"session_id": session_id, "status": "queued", "run_id": run_id}
 
 
 # ============================================================
 # GET /simulate/simnibs/results/{session_id}/{model_name}/{output_type}
+# (legacy — no run_id; kept for backward compatibility)
 # ============================================================
 @app.get("/simulate/simnibs/results/{session_id}/{model_name}/{output_type}")
 async def get_simnibs_result(session_id: str, model_name: str, output_type: str):
@@ -406,6 +447,33 @@ async def get_simnibs_result(session_id: str, model_name: str, output_type: str)
         raise HTTPException(
             status_code=404,
             detail=f"SimNIBS output '{output_type}' not found for model '{model_name}'. Run simulation first."
+        )
+
+    return FileResponse(
+        path=str(out_path),
+        filename=f"simnibs_{model_name}_{output_type}.nii.gz",
+        media_type="application/gzip",
+    )
+
+
+# ============================================================
+# GET /simulate/simnibs/results/{session_id}/{model_name}/{run_id}/{output_type}
+# (new — includes run_id so each electrode configuration is isolated)
+# ============================================================
+@app.get("/simulate/simnibs/results/{session_id}/{model_name}/{run_id}/{output_type}")
+async def get_simnibs_result_by_run(session_id: str, model_name: str, run_id: str, output_type: str):
+    if output_type not in ("magnJ", "wm_magnJ", "gm_magnJ", "wm_gm_magnJ"):
+        raise HTTPException(status_code=400, detail="output_type must be: magnJ, wm_magnJ, gm_magnJ, or wm_gm_magnJ")
+
+    try:
+        out_path = simnibs_output_path(session_id, model_name, output_type, run_id)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    if not out_path.exists():
+        raise HTTPException(
+            status_code=404,
+            detail=f"SimNIBS output '{output_type}' not found for model '{model_name}' run '{run_id}'. Run simulation first."
         )
 
     return FileResponse(

--- a/api_v2/runtime/roast_runner.py
+++ b/api_v2/runtime/roast_runner.py
@@ -147,7 +147,8 @@ class ROASTRunner:
         self.session_id = session_id
         self.model_name = model_name
         self.payload = payload
-        self.work_dir = roast_working_dir(session_id, model_name)
+        self.run_id = payload.get("run_id", "")
+        self.work_dir = roast_working_dir(session_id, model_name, self.run_id)
 
     # ------------------------------------------------------------------
     def _emit(self, event: str, progress: int, detail: str | None = None):
@@ -156,7 +157,7 @@ class ROASTRunner:
             data["detail"] = detail
         push_event(self.session_id, data)
         log_event(self.session_id, data)
-        set_roast_progress(self.session_id, progress, self.model_name)
+        set_roast_progress(self.session_id, progress, self.model_name, self.run_id)
 
     # ------------------------------------------------------------------
     def prepare_working_directory(self) -> str:
@@ -587,7 +588,7 @@ class ROASTRunner:
         Automatically retries once with a refined mesh on FEM/meshing failures.
         """
         try:
-            set_roast_status(self.session_id, "running", self.model_name)
+            set_roast_status(self.session_id, "running", self.model_name, self.run_id)
             self._emit("roast_start", 2)
 
             t1_path = self.prepare_working_directory()
@@ -615,13 +616,13 @@ class ROASTRunner:
                 break  # success
 
             self.collect_outputs()
-            set_roast_status(self.session_id, "complete", self.model_name)
+            set_roast_status(self.session_id, "complete", self.model_name, self.run_id)
             self._emit("roast_complete", 100)
             session_log(self.session_id, "[ROAST] Completed successfully")
 
         except Exception as e:
             log_error(self.session_id, f"[ROAST] Failed: {e}")
-            set_roast_status(self.session_id, "error", self.model_name)
+            set_roast_status(self.session_id, "error", self.model_name, self.run_id)
             self._emit("roast_error", -1, detail=str(e))
             raise
 
@@ -631,7 +632,7 @@ class ROASTRunner:
         expected = ["voltage", "efield", "emag"]
         missing = []
         for output_type in expected:
-            path = roast_output_path(self.session_id, output_type, self.model_name, self.sim_tag)
+            path = roast_output_path(self.session_id, output_type, self.model_name, self.sim_tag, self.run_id)
             if not path.exists():
                 missing.append(str(path))
 

--- a/api_v2/runtime/session.py
+++ b/api_v2/runtime/session.py
@@ -35,8 +35,10 @@ def model_output_path(session_id: str, model_name: str) -> Path:
 # -----------------------------------------------------------
 # ROAST HELPERS
 # -----------------------------------------------------------
-def roast_working_dir(session_id: str, model_name: str = "") -> Path:
-    if model_name:
+def roast_working_dir(session_id: str, model_name: str = "", run_id: str = "") -> Path:
+    if model_name and run_id:
+        d = session_path(session_id) / "roast" / model_name / run_id
+    elif model_name:
         d = session_path(session_id) / "roast" / model_name
     else:
         d = session_path(session_id) / "roast"
@@ -44,8 +46,8 @@ def roast_working_dir(session_id: str, model_name: str = "") -> Path:
     return d
 
 
-def roast_output_path(session_id: str, output_type: str, model_name: str = "", simulation_tag: str = "tDCSLAB") -> Path:
-    work_dir = roast_working_dir(session_id, model_name)
+def roast_output_path(session_id: str, output_type: str, model_name: str = "", simulation_tag: str = "tDCSLAB", run_id: str = "") -> Path:
+    work_dir = roast_working_dir(session_id, model_name, run_id)
     if output_type == "mask_elec":
         matches = sorted(work_dir.glob("T1_sim_*_mask_elec.nii"), key=lambda p: p.stat().st_mtime, reverse=True)
         return matches[0] if matches else work_dir / "_missing_mask_elec.nii"
@@ -65,8 +67,11 @@ def roast_output_path(session_id: str, output_type: str, model_name: str = "", s
 # -----------------------------------------------------------
 # SIMNIBS HELPERS
 # -----------------------------------------------------------
-def simnibs_working_dir(session_id: str, model_name: str) -> Path:
-    d = session_path(session_id) / "simnibs" / model_name
+def simnibs_working_dir(session_id: str, model_name: str, run_id: str = "") -> Path:
+    if run_id:
+        d = session_path(session_id) / "simnibs" / model_name / run_id
+    else:
+        d = session_path(session_id) / "simnibs" / model_name
     d.mkdir(parents=True, exist_ok=True)
     return d
 
@@ -85,14 +90,14 @@ def simnibs_charm_base_dir(session_id: str) -> Path:
 SIMNIBS_OUTPUT_TYPES = ("magnJ", "wm_magnJ", "gm_magnJ", "wm_gm_magnJ")
 
 
-def simnibs_output_path(session_id: str, model_name: str, output_type: str) -> Path:
+def simnibs_output_path(session_id: str, model_name: str, output_type: str, run_id: str = "") -> Path:
     """Collected SimNIBS output NIfTIs per segmentation model."""
     if output_type not in SIMNIBS_OUTPUT_TYPES:
         raise ValueError(
             f"Unknown SimNIBS output type: {output_type!r}. "
             f"Valid: {SIMNIBS_OUTPUT_TYPES}"
         )
-    return simnibs_working_dir(session_id, model_name) / "outputs" / f"{output_type}.nii.gz"
+    return simnibs_working_dir(session_id, model_name, run_id) / "outputs" / f"{output_type}.nii.gz"
 
 
 # -----------------------------------------------------------

--- a/api_v2/runtime/simnibs_runner.py
+++ b/api_v2/runtime/simnibs_runner.py
@@ -211,7 +211,8 @@ class SimNIBSRunner:
         self.session_id = session_id
         self.payload    = payload
         self.model_name = payload.get("model_name", "")
-        self.work_dir   = simnibs_working_dir(session_id, self.model_name)
+        self.run_id     = payload.get("run_id", "")
+        self.work_dir   = simnibs_working_dir(session_id, self.model_name, self.run_id)
 
     # ------------------------------------------------------------------
     def _emit(self, event: str, progress: int, detail: str | None = None):
@@ -220,7 +221,7 @@ class SimNIBSRunner:
             data["detail"] = detail
         push_event(self.session_id, data)
         log_event(self.session_id, data)
-        set_simnibs_progress(self.session_id, progress, self.model_name)
+        set_simnibs_progress(self.session_id, progress, self.model_name, self.run_id)
 
     # ------------------------------------------------------------------
     def _run_proc(self, cmd: list, tag: str, cwd: Path, deadline: float) -> None:
@@ -545,7 +546,7 @@ class SimNIBSRunner:
     def run(self):
         """Full pipeline: remap seg → charm base → mesh → FEM → collect."""
         try:
-            set_simnibs_status(self.session_id, "running", self.model_name)
+            set_simnibs_status(self.session_id, "running", self.model_name, self.run_id)
             self._emit("simnibs_start", 2)
 
             seg_source = self.payload.get("seg_source", "deep_learning")
@@ -560,12 +561,12 @@ class SimNIBSRunner:
             self.run_fem(mesh_path)
             self.collect_outputs()
 
-            set_simnibs_status(self.session_id, "complete", self.model_name)
+            set_simnibs_status(self.session_id, "complete", self.model_name, self.run_id)
             self._emit("simnibs_complete", 100)
             session_log(self.session_id, "[SimNIBS] Completed successfully")
 
         except Exception as exc:
             log_error(self.session_id, f"[SimNIBS] Failed: {exc}")
-            set_simnibs_status(self.session_id, "error", self.model_name)
+            set_simnibs_status(self.session_id, "error", self.model_name, self.run_id)
             self._emit("simnibs_error", -1, detail=str(exc))
             raise

--- a/api_v2/services/redis_client.py
+++ b/api_v2/services/redis_client.py
@@ -160,23 +160,27 @@ def get_roast_job_data(session_id: str) -> dict | None:
     return json.loads(raw) if raw else None
 
 
-def set_roast_status(session_id: str, status: str, model_name: str = ""):
-    key = ROAST_JOB_STATUS_PREFIX + (f"{session_id}:{model_name}" if model_name else session_id)
+def set_roast_status(session_id: str, status: str, model_name: str = "", run_id: str = ""):
+    parts = [p for p in [session_id, model_name, run_id] if p]
+    key = ROAST_JOB_STATUS_PREFIX + ":".join(parts)
     redis_client.set(key, status)
 
 
-def get_roast_status(session_id: str, model_name: str = "") -> str | None:
-    key = ROAST_JOB_STATUS_PREFIX + (f"{session_id}:{model_name}" if model_name else session_id)
+def get_roast_status(session_id: str, model_name: str = "", run_id: str = "") -> str | None:
+    parts = [p for p in [session_id, model_name, run_id] if p]
+    key = ROAST_JOB_STATUS_PREFIX + ":".join(parts)
     return redis_client.get(key)
 
 
-def set_roast_progress(session_id: str, progress: float, model_name: str = ""):
-    key = ROAST_PROGRESS_PREFIX + (f"{session_id}:{model_name}" if model_name else session_id)
+def set_roast_progress(session_id: str, progress: float, model_name: str = "", run_id: str = ""):
+    parts = [p for p in [session_id, model_name, run_id] if p]
+    key = ROAST_PROGRESS_PREFIX + ":".join(parts)
     redis_client.set(key, progress)
 
 
-def get_roast_progress(session_id: str, model_name: str = "") -> float:
-    key = ROAST_PROGRESS_PREFIX + (f"{session_id}:{model_name}" if model_name else session_id)
+def get_roast_progress(session_id: str, model_name: str = "", run_id: str = "") -> float:
+    parts = [p for p in [session_id, model_name, run_id] if p]
+    key = ROAST_PROGRESS_PREFIX + ":".join(parts)
     p = redis_client.get(key)
     return float(p) if p else 0.0
 
@@ -204,23 +208,27 @@ def get_simnibs_job_data(session_id: str) -> dict | None:
     return json.loads(raw) if raw else None
 
 
-def set_simnibs_status(session_id: str, status: str, model_name: str = ""):
-    key = SIMNIBS_JOB_STATUS_PREFIX + (f"{session_id}:{model_name}" if model_name else session_id)
+def set_simnibs_status(session_id: str, status: str, model_name: str = "", run_id: str = ""):
+    parts = [p for p in [session_id, model_name, run_id] if p]
+    key = SIMNIBS_JOB_STATUS_PREFIX + ":".join(parts)
     redis_client.set(key, status)
 
 
-def get_simnibs_status(session_id: str, model_name: str = "") -> str | None:
-    key = SIMNIBS_JOB_STATUS_PREFIX + (f"{session_id}:{model_name}" if model_name else session_id)
+def get_simnibs_status(session_id: str, model_name: str = "", run_id: str = "") -> str | None:
+    parts = [p for p in [session_id, model_name, run_id] if p]
+    key = SIMNIBS_JOB_STATUS_PREFIX + ":".join(parts)
     return redis_client.get(key)
 
 
-def set_simnibs_progress(session_id: str, progress: float, model_name: str = ""):
-    key = SIMNIBS_PROGRESS_PREFIX + (f"{session_id}:{model_name}" if model_name else session_id)
+def set_simnibs_progress(session_id: str, progress: float, model_name: str = "", run_id: str = ""):
+    parts = [p for p in [session_id, model_name, run_id] if p]
+    key = SIMNIBS_PROGRESS_PREFIX + ":".join(parts)
     redis_client.set(key, progress)
 
 
-def get_simnibs_progress(session_id: str, model_name: str = "") -> float:
-    key = SIMNIBS_PROGRESS_PREFIX + (f"{session_id}:{model_name}" if model_name else session_id)
+def get_simnibs_progress(session_id: str, model_name: str = "", run_id: str = "") -> float:
+    parts = [p for p in [session_id, model_name, run_id] if p]
+    key = SIMNIBS_PROGRESS_PREFIX + ":".join(parts)
     p = redis_client.get(key)
     return float(p) if p else 0.0
 

--- a/ui_v2/app/components/tes/TESPage.tsx
+++ b/ui_v2/app/components/tes/TESPage.tsx
@@ -120,6 +120,7 @@ interface RunState {
   error?:      string;
   config?:     RunConfig;
   completedAt?: number;
+  runId?:      string;
 }
 
 type PanelView =
@@ -319,7 +320,8 @@ export default function TESPage() {
     if (next.solver === "roast") {
       setRunState(key, { status: "running", progress: 2, step: "Starting…" });
       try {
-        await startSimulation(sessionId!, next.model, quality, recipe, electype, segSource);
+        const { run_id } = await startSimulation(sessionId!, next.model, quality, recipe, electype, segSource);
+        setRunState(key, { status: "running", progress: 2, step: "Starting…", runId: run_id });
       } catch (e: unknown) {
         setRunState(key, { status: "error", error: (e as Error).message });
         runningRef.current = false;
@@ -352,7 +354,8 @@ export default function TESPage() {
     } else {
       setRunState(key, { status: "running", progress: 2, step: "Starting…" });
       try {
-        await startSimNIBSSimulation(sessionId!, next.model, recipe, electype);
+        const { run_id } = await startSimNIBSSimulation(sessionId!, next.model, recipe, electype);
+        setRunState(key, { status: "running", progress: 2, step: "Starting…", runId: run_id });
       } catch (e: unknown) {
         setRunState(key, { status: "error", error: (e as Error).message });
         runningRef.current = false;
@@ -1028,29 +1031,41 @@ export default function TESPage() {
           )}
           {(panelView.type === "roast" || panelView.type === "simnibs") && (
             <div className="h-full p-4">
-              <RoastViewer
-                key={`${panelView.runKey}:${runStates[panelView.runKey]?.completedAt ?? ""}`}
-                inputUrl={inputBlobUrl}
-                sessionId={sessionId}
-                modelName={panelView.model}
-                solver={panelView.type}
-              />
+              {runStates[panelView.runKey]?.status !== "complete" ? (
+                <div className="flex h-full flex-col items-center justify-center gap-3 text-foreground-muted">
+                  <div className="h-8 w-8 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+                  <p className="text-sm">Simulation in progress — results will appear here when complete.</p>
+                </div>
+              ) : (
+                <RoastViewer
+                  key={`${panelView.runKey}:${runStates[panelView.runKey]?.completedAt ?? ""}`}
+                  inputUrl={inputBlobUrl}
+                  sessionId={sessionId}
+                  modelName={panelView.model}
+                  runId={runStates[panelView.runKey]?.runId ?? ""}
+                  solver={panelView.type}
+                />
+              )}
             </div>
           )}
-          {panelView.type === "comparison" && (
-            <div className="h-full p-4">
-              <TESComparisonViewer
-                key={`${panelView.model}:comparison:${
-                  Math.max(0, ...visibleRuns.filter(r => r.model === panelView.model && r.solver === "roast" && r.state.status === "complete").map(r => r.state.completedAt ?? 0))
-                }:${
-                  Math.max(0, ...visibleRuns.filter(r => r.model === panelView.model && r.solver === "simnibs" && r.state.status === "complete").map(r => r.state.completedAt ?? 0))
-                }`}
-                inputUrl={inputBlobUrl}
-                sessionId={sessionId}
-                modelName={panelView.model}
-              />
-            </div>
-          )}
+          {panelView.type === "comparison" && (() => {
+            const completedRoastRuns = visibleRuns.filter(r => r.model === panelView.model && r.solver === "roast" && r.state.status === "complete");
+            const completedSimnibsRuns = visibleRuns.filter(r => r.model === panelView.model && r.solver === "simnibs" && r.state.status === "complete");
+            const latestRoast = completedRoastRuns.reduce<VisibleRun | null>((best, r) => !best || (r.state.completedAt ?? 0) > (best.state.completedAt ?? 0) ? r : best, null);
+            const latestSimnibs = completedSimnibsRuns.reduce<VisibleRun | null>((best, r) => !best || (r.state.completedAt ?? 0) > (best.state.completedAt ?? 0) ? r : best, null);
+            return (
+              <div className="h-full p-4">
+                <TESComparisonViewer
+                  key={`${panelView.model}:comparison:${latestRoast?.state.completedAt ?? 0}:${latestSimnibs?.state.completedAt ?? 0}`}
+                  inputUrl={inputBlobUrl}
+                  sessionId={sessionId}
+                  modelName={panelView.model}
+                  roastRunId={latestRoast?.state.runId ?? ""}
+                  simnibsRunId={latestSimnibs?.state.runId ?? ""}
+                />
+              </div>
+            );
+          })()}
         </div>
 
       </div>

--- a/ui_v2/app/components/tes/TESWizard.tsx
+++ b/ui_v2/app/components/tes/TESWizard.tsx
@@ -33,6 +33,7 @@ interface RunState {
   progress: number;
   step:     string;
   error?:   string;
+  runId?:   string;
 }
 
 interface TESWizardProps {
@@ -210,7 +211,8 @@ export default function TESWizard({ sessionId, models, inputBlobUrl }: TESWizard
       setRunState(key, { status: "running", progress: 2, step: "Starting..." });
 
       try {
-        await startSimulation(sessionId, next.model, quality, recipe, electype, roastSegSource);
+        const { run_id } = await startSimulation(sessionId, next.model, quality, recipe, electype, roastSegSource);
+        setRunState(key, { status: "running", progress: 2, step: "Starting...", runId: run_id });
       } catch (e: unknown) {
         setRunState(key, { status: "error", error: (e as Error).message || "Failed to start ROAST" });
         runningRef.current = false;
@@ -249,7 +251,8 @@ export default function TESWizard({ sessionId, models, inputBlobUrl }: TESWizard
       setRunState(key, { status: "running", progress: 2, step: "Starting..." });
 
       try {
-        await startSimNIBSSimulation(sessionId, next.model, recipe, electype, simnibsSegSource);
+        const { run_id } = await startSimNIBSSimulation(sessionId, next.model, recipe, electype, simnibsSegSource);
+        setRunState(key, { status: "running", progress: 2, step: "Starting...", runId: run_id });
       } catch (e: unknown) {
         setRunState(key, { status: "error", error: (e as Error).message || "Failed to start SimNIBS" });
         runningRef.current = false;
@@ -773,6 +776,7 @@ export default function TESWizard({ sessionId, models, inputBlobUrl }: TESWizard
                 inputUrl={inputBlobUrl}
                 sessionId={sessionId}
                 modelName={activeView.model}
+                runId={runStates[runKey(activeView.model, activeView.solver)]?.runId ?? ""}
                 solver={activeView.solver}
               />
             )}
@@ -781,6 +785,8 @@ export default function TESWizard({ sessionId, models, inputBlobUrl }: TESWizard
                 inputUrl={inputBlobUrl}
                 sessionId={sessionId}
                 modelName={activeView.model}
+                roastRunId={runStates[runKey(activeView.model, "roast")]?.runId ?? ""}
+                simnibsRunId={runStates[runKey(activeView.model, "simnibs")]?.runId ?? ""}
               />
             )}
           </div>

--- a/ui_v2/app/components/viewer/RoastViewer.tsx
+++ b/ui_v2/app/components/viewer/RoastViewer.tsx
@@ -55,10 +55,11 @@ interface RoastViewerProps {
   inputUrl: string;
   sessionId: string;
   modelName: string;
+  runId: string;
   solver?: "roast" | "simnibs";
 }
 
-export default function RoastViewer({ inputUrl, sessionId, modelName, solver = "roast" }: RoastViewerProps) {
+export default function RoastViewer({ inputUrl, sessionId, modelName, runId, solver = "roast" }: RoastViewerProps) {
   const PANELS = solver === "simnibs" ? SIMNIBS_PANELS : ROAST_PANELS;
   const canvasRefs = [useRef<HTMLCanvasElement>(null), useRef<HTMLCanvasElement>(null)];
   const nvRefs = useRef<(Niivue | null)[]>([null, null]);
@@ -113,15 +114,15 @@ export default function RoastViewer({ inputUrl, sessionId, modelName, solver = "
     if (bufferCache.current[type]) return bufferCache.current[type]!;
     try {
       const blob = solver === "simnibs"
-        ? await getSimNIBSResult(sessionId, modelName, SIMNIBS_TYPE_MAP[type])
-        : await getSimulationResult(sessionId, modelName, type);
+        ? await getSimNIBSResult(sessionId, modelName, runId, SIMNIBS_TYPE_MAP[type])
+        : await getSimulationResult(sessionId, modelName, runId, type);
       const buf  = await blob.arrayBuffer();
       bufferCache.current[type] = buf;
       return buf;
     } catch {
       return null;
     }
-  }, [sessionId, modelName, solver]);
+  }, [sessionId, modelName, runId, solver]);
 
   const loadOverlay = useCallback(async (
     nv: Niivue,
@@ -259,7 +260,7 @@ export default function RoastViewer({ inputUrl, sessionId, modelName, solver = "
       // Fetch masks
       const fetchMask = async (type: "mask_elec" | "mask_gel"): Promise<ArrayBuffer | null> => {
         try {
-          const blob = await getSimulationResult(sessionId, modelName, type);
+          const blob = await getSimulationResult(sessionId, modelName, runId, type);
           const buf = await blob.arrayBuffer();
           return buf.byteLength > 0 ? buf : null;
         } catch { return null; }
@@ -303,7 +304,7 @@ export default function RoastViewer({ inputUrl, sessionId, modelName, solver = "
     initElec().catch(() => { if (mounted) setElecError(true); });
     return () => { mounted = false; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialized, inputUrl, sessionId, modelName, solver]);
+  }, [initialized, inputUrl, sessionId, modelName, runId, solver]);
 
   // Sync electrode mask opacity
   useEffect(() => {
@@ -541,7 +542,7 @@ export default function RoastViewer({ inputUrl, sessionId, modelName, solver = "
               <div className="flex items-center gap-3 px-4 py-5 text-foreground-muted">
                 <AlertTriangle className="h-4 w-4 shrink-0 text-foreground-muted/60" />
                 <p className="text-sm">
-                  {panel.label} output was not produced by the solver — only E-field magnitude is available.
+                  {panel.label} output is not yet available — the simulation may still be running, or this file was not produced by the solver.
                 </p>
               </div>
             ) : (

--- a/ui_v2/app/components/viewer/TESComparisonViewer.tsx
+++ b/ui_v2/app/components/viewer/TESComparisonViewer.tsx
@@ -24,9 +24,11 @@ interface TESComparisonViewerProps {
   inputUrl: string;
   sessionId: string;
   modelName: string;
+  roastRunId?: string;
+  simnibsRunId?: string;
 }
 
-export default function TESComparisonViewer({ inputUrl, sessionId, modelName }: TESComparisonViewerProps) {
+export default function TESComparisonViewer({ inputUrl, sessionId, modelName, roastRunId = "", simnibsRunId = "" }: TESComparisonViewerProps) {
   // One canvas per panel — 4 total
   const canvasRefs = [
     useRef<HTMLCanvasElement>(null),
@@ -65,15 +67,15 @@ export default function TESComparisonViewer({ inputUrl, sessionId, modelName }: 
     if (bufferCache.current[key]) return bufferCache.current[key];
     try {
       const blob = solver === "roast"
-        ? await getSimulationResult(sessionId, modelName, type as RoastOutputType)
-        : await getSimNIBSResult(sessionId, modelName, type as SimNIBSOutputType);
+        ? await getSimulationResult(sessionId, modelName, roastRunId, type as RoastOutputType)
+        : await getSimNIBSResult(sessionId, modelName, simnibsRunId, type as SimNIBSOutputType);
       const buf = await blob.arrayBuffer();
       bufferCache.current[key] = buf;
       return buf;
     } catch {
       return null;
     }
-  }, [sessionId, modelName]);
+  }, [sessionId, modelName, roastRunId, simnibsRunId]);
 
   const loadOverlay = useCallback(async (
     nv: Niivue,

--- a/ui_v2/lib/api.ts
+++ b/ui_v2/lib/api.ts
@@ -161,6 +161,7 @@ export async function getInput(sessionId: string): Promise<Blob> {
 export interface SimulateResponse {
   session_id: string;
   status: "queued";
+  run_id: string;
 }
 
 export async function startSimulation(
@@ -243,9 +244,13 @@ export function connectROASTSSE(
 export async function getSimulationResult(
   sessionId: string,
   modelName: string,
+  runId: string,
   outputType: "voltage" | "efield" | "emag" | "mask_elec" | "mask_gel"
 ): Promise<Blob> {
-  const res = await fetch(`${API_BASE}/simulate/results/${sessionId}/${modelName}/${outputType}`);
+  const path = runId
+    ? `${API_BASE}/simulate/results/${sessionId}/${modelName}/${runId}/${outputType}`
+    : `${API_BASE}/simulate/results/${sessionId}/${modelName}/${outputType}`;
+  const res = await fetch(path);
   if (!res.ok) throw new Error(`Simulation result not found: ${outputType}`);
   return await res.blob();
 }
@@ -336,9 +341,13 @@ export type SimNIBSOutputType = "magnJ" | "wm_magnJ" | "gm_magnJ" | "wm_gm_magnJ
 export async function getSimNIBSResult(
   sessionId: string,
   modelName: string,
+  runId: string,
   outputType: SimNIBSOutputType
 ): Promise<Blob> {
-  const res = await fetch(`${API_BASE}/simulate/simnibs/results/${sessionId}/${modelName}/${outputType}`);
+  const path = runId
+    ? `${API_BASE}/simulate/simnibs/results/${sessionId}/${modelName}/${runId}/${outputType}`
+    : `${API_BASE}/simulate/simnibs/results/${sessionId}/${modelName}/${outputType}`;
+  const res = await fetch(path);
   if (!res.ok) throw new Error(`SimNIBS result not found: ${outputType}`);
   return await res.blob();
 }


### PR DESCRIPTION
Each ROAST/SimNIBS job now gets a run_id (12-char hex UUID) generated at enqueue time. Outputs are stored under run_id subdirectories so multiple runs of the same model with different electrode configs no longer overwrite each other.

- session.py: roast_working_dir/simnibs_working_dir/output_path functions accept optional run_id, path becomes model/run_id/
- redis_client.py: status/progress keys include run_id when present
- app.py: generate run_id on enqueue, new result endpoints with run_id in path, return run_id in POST response
- roast_runner.py/simnibs_runner.py: use run_id from payload
- lib/api.ts: SimulateResponse includes run_id; getSimulationResult and getSimNIBSResult accept runId param
- RoastViewer: accepts runId prop, passes to all fetch calls
- TESPage/TESWizard: store runId from API response in RunState, pass to RoastViewer and TESComparisonViewer