### PR TITLE
fix(deploy): handle missing api/.env gracefully

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -36,13 +36,21 @@ jobs:
             git checkout main
             git reset --hard origin/main
 
+            # Use api/.env if it exists, otherwise rely on docker-compose.yml defaults
+            ENV_FILE_FLAG=""
+            if [ -f ./api/.env ]; then
+              ENV_FILE_FLAG="--env-file ./api/.env"
+              echo "[deploy] Using api/.env"
+            else
+              echo "[deploy] No api/.env found, using docker-compose.yml defaults"
+            fi
+
             echo "[deploy] Building new image (old container stays up during build)..."
-            cd /home/chintan/GRACE-Web-Tool
-            DOCKER_BUILDKIT=1 docker compose --env-file ./api/.env build api
+            DOCKER_BUILDKIT=1 docker compose $ENV_FILE_FLAG build api
 
             echo "[deploy] Swapping containers (minimal downtime)..."
-            docker compose --env-file ./api/.env down || true
-            docker compose --env-file ./api/.env up -d
+            docker compose $ENV_FILE_FLAG down || true
+            docker compose $ENV_FILE_FLAG up -d
 
             echo "[deploy] Checking container status..."
             docker compose ps


### PR DESCRIPTION
The deploy script hardcoded --env-file ./api/.env which fails when the file doesn't exist on the server. Now checks for the file first and falls back to docker-compose.yml defaults.