### PR TITLE
fix(tes): unblock SSE queue on disconnect and cache ROAST prepared files

### DIFF
--- a/api/runtime/roast_runner.py
+++ b/api/runtime/roast_runner.py
@@ -160,12 +160,54 @@ class ROASTRunner:
         set_roast_progress(self.session_id, progress, self.model_name, self.run_id)
 
     # ------------------------------------------------------------------
+    def _prepared_cache_dir(self) -> Path:
+        """
+        Shared preparation cache for this model+seg_source combination.
+        Stored one level above run directories so all runs of the same model can reuse it.
+        """
+        seg_source = self.payload.get("seg_source", "nn")
+        return self.work_dir.parent / f"_prepared_{seg_source}"
+
+    def _restore_from_cache(self, cache_dir: Path, t1_nii: Path) -> bool:
+        """Copy cached prepared files into this run's working directory. Returns True on success."""
+        required = [cache_dir / "T1.nii"]
+        if not all(p.exists() for p in required):
+            return False
+        for src in cache_dir.iterdir():
+            shutil.copy2(str(src), str(self.work_dir / src.name))
+        session_log(self.session_id, f"[ROAST] Reused prepared files from cache → {cache_dir}")
+        return True
+
+    def _save_to_cache(self, cache_dir: Path) -> None:
+        """Cache the prepared files so subsequent runs can skip expensive preprocessing."""
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cacheable = [
+            "T1.nii",
+            "T1_T1orT2_masks.nii",
+            "T1_ras_T1orT2_masks.nii",
+            "c1T1_T1orT2.nii",
+            "c1T1_ras_T1orT2.nii",
+        ]
+        for name in cacheable:
+            src = self.work_dir / name
+            if src.exists():
+                shutil.copy2(str(src), str(cache_dir / name))
+        session_log(self.session_id, f"[ROAST] Saved prepared files to cache → {cache_dir}")
+
     def prepare_working_directory(self) -> str:
         """
         Gunzip T1 and segmentation mask into the roast/ working directory.
         Returns the absolute path to T1.nii.
+
+        Results are cached at the model level so subsequent runs with the same
+        model and seg_source skip the expensive nibabel morphological operations.
         """
         session_log(self.session_id, "[ROAST] Preparing working directory")
+
+        t1_nii = self.work_dir / "T1.nii"
+        cache_dir = self._prepared_cache_dir()
+        if self._restore_from_cache(cache_dir, t1_nii):
+            return str(t1_nii)
 
         # Use the T1 that matches the segmentation mask's coordinate space.
         # FS models produce masks in FreeSurfer conformed space (256³ 1mm isotropic);
@@ -348,6 +390,7 @@ class ROASTRunner:
                 shutil.copy(t1_nii, self.work_dir / dummy_name)
             session_log(self.session_id, "[ROAST] Dummy c1 files written (bypasses SPM step 1)")
 
+        self._save_to_cache(cache_dir)
         return str(t1_nii)
 
     # ------------------------------------------------------------------

--- a/ui/app/components/tes/TESPage.tsx
+++ b/ui/app/components/tes/TESPage.tsx
@@ -349,6 +349,12 @@ export default function TESPage() {
           runningRef.current = false;
           processQueue();
         }
+      }, () => {
+        // SSE dropped without complete/error — unblock the queue
+        clearActiveSim();
+        setRunState(key, { status: "error", error: "Connection lost — simulation may still be running." });
+        runningRef.current = false;
+        processQueue();
       });
 
     } else {
@@ -383,6 +389,11 @@ export default function TESPage() {
           runningRef.current = false;
           processQueue();
         }
+      }, () => {
+        clearActiveSim();
+        setRunState(key, { status: "error", error: "Connection lost — simulation may still be running." });
+        runningRef.current = false;
+        processQueue();
       });
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/ui/app/components/tes/TESWizard.tsx
+++ b/ui/app/components/tes/TESWizard.tsx
@@ -242,6 +242,11 @@ export default function TESWizard({ sessionId, models, inputBlobUrl }: TESWizard
             processQueue();
           }
         },
+        () => {
+          setRunState(key, { status: "error", error: "Connection lost — simulation may still be running." });
+          runningRef.current = false;
+          processQueue();
+        },
       );
 
     } else {
@@ -280,6 +285,11 @@ export default function TESWizard({ sessionId, models, inputBlobUrl }: TESWizard
             runningRef.current = false;
             processQueue();
           }
+        },
+        () => {
+          setRunState(key, { status: "error", error: "Connection lost — simulation may still be running." });
+          runningRef.current = false;
+          processQueue();
         },
       );
     }


### PR DESCRIPTION
Two bugs fixed:

1. connectROASTSSE/connectSimNIBSSSE were called without an onDisconnect handler in both TESPage and TESWizard. If the SSE connection dropped for any reason (network blip, server-side close after stream_end), runningRef.current stayed true permanently — causing the second simulation tab to spin in "Simulation in progress" forever and session 1 to sometimes show no outputs. onDisconnect now resets the queue state and advances to the next run.

2. prepare_working_directory ran expensive nibabel morphological ops (3D binary_closing + per-slice binary_fill_holes on 256³ volumes) for every run, even when the same model was already prepared for a previous run. Results are now cached at the model level under sessions/{id}/roast/{model}/_prepared_{seg_source}/ and reused on subsequent runs, eliminating the multi-minute "Preparing files" delay for second and later electrode configs.