### PR TITLE
feat(admin): add admin platform at /dev with auth, health, jobs, logs, audit

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -25,8 +25,8 @@ from services.redis_client import (
     enqueue_roast_job, get_roast_status, get_roast_progress, set_roast_status,
     enqueue_simnibs_job, get_simnibs_status, get_simnibs_progress, set_simnibs_status,
 )
-from config import GPU_COUNT, SESSION_DIR, DB_PATH, NOTIFY_TOKEN_TTL, FRONTEND_URL, ALLOWED_ORIGINS
-from services.auth import require_jwt
+from config import GPU_COUNT, SESSION_DIR, DB_PATH, NOTIFY_TOKEN_TTL, FRONTEND_URL, ALLOWED_ORIGINS, ADMIN_PASSWORD
+from services.auth import require_jwt, create_jwt
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -735,18 +735,124 @@ def get_logs(session_id: str, _: str = Depends(require_jwt)):
 
 
 # ============================================================
+# POST /admin/login
+# ============================================================
+@app.post("/admin/login")
+async def admin_login(body: dict = Body(...)):
+    password = body.get("password", "")
+    if not password or password != ADMIN_PASSWORD:
+        raise HTTPException(status_code=401, detail="Invalid password")
+    token = create_jwt({"role": "admin"})
+    return {"token": token}
+
+
+# ============================================================
+# GET /admin/jobs  — aggregate live jobs across all schedulers
+# ============================================================
+@app.get("/admin/jobs")
+def get_admin_jobs(_: str = Depends(require_jwt)):
+    jobs = []
+
+    # GPU locks: HASH  gpu_id → "free" | "{session_id}:{model}"
+    gpu_lock_map = redis_client.hgetall("gpu_locks") or {}
+
+    # --- GPU segmentation jobs ---
+    # job_status:{session_id} is a HASH of model → status
+    for key in redis_client.scan_iter("job_status:*"):
+        session_id = key[len("job_status:"):]
+        model_statuses = redis_client.hgetall(key)
+        for model, status in model_statuses.items():
+            if status == "complete":
+                continue
+            progress_raw = redis_client.hget("progress", f"{session_id}:{model}")
+            progress = float(progress_raw) if progress_raw else 0.0
+            gpu = next(
+                (gid for gid, holder in gpu_lock_map.items() if holder == f"{session_id}:{model}"),
+                None,
+            )
+            jobs.append({
+                "type": "gpu_seg",
+                "session_id": session_id,
+                "model": model,
+                "run_id": None,
+                "status": status,
+                "progress": progress,
+                "gpu": gpu,
+            })
+
+    # --- ROAST jobs ---
+    for key in redis_client.scan_iter("roast_job_status:*"):
+        suffix = key[len("roast_job_status:"):]
+        parts = suffix.split(":", 2)
+        session_id = parts[0]
+        model = parts[1] if len(parts) > 1 else ""
+        run_id = parts[2] if len(parts) > 2 else ""
+        status = redis_client.get(key) or "unknown"
+        if status == "complete":
+            continue
+        progress_raw = redis_client.get(f"roast_progress:{suffix}")
+        progress = float(progress_raw) if progress_raw else 0.0
+        jobs.append({
+            "type": "roast",
+            "session_id": session_id,
+            "model": model,
+            "run_id": run_id,
+            "status": status,
+            "progress": progress,
+            "gpu": None,
+        })
+
+    # --- SimNIBS jobs ---
+    for key in redis_client.scan_iter("simnibs_job_status:*"):
+        suffix = key[len("simnibs_job_status:"):]
+        parts = suffix.split(":", 2)
+        session_id = parts[0]
+        model = parts[1] if len(parts) > 1 else ""
+        run_id = parts[2] if len(parts) > 2 else ""
+        status = redis_client.get(key) or "unknown"
+        if status == "complete":
+            continue
+        progress_raw = redis_client.get(f"simnibs_progress:{suffix}")
+        progress = float(progress_raw) if progress_raw else 0.0
+        jobs.append({
+            "type": "simnibs",
+            "session_id": session_id,
+            "model": model,
+            "run_id": run_id,
+            "status": status,
+            "progress": progress,
+            "gpu": None,
+        })
+
+    queue_depths = {
+        "gpu_seg": redis_client.llen("job_queue"),
+        "roast": redis_client.llen("roast_job_queue"),
+        "simnibs": redis_client.llen("simnibs_job_queue"),
+    }
+
+    return {"jobs": jobs, "queue_depths": queue_depths}
+
+
+# ============================================================
 # GET /admin/audit
 # ============================================================
 @app.get("/admin/audit")
-def get_audit(_: str = Depends(require_jwt)):
+def get_audit(
+    _: str = Depends(require_jwt),
+    offset: int = 0,
+    limit: int = 100,
+):
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
+    c.execute("SELECT COUNT(*) FROM audit")
+    total = c.fetchone()[0]
     c.execute(
-        "SELECT ts, session_id, model, event, detail FROM audit ORDER BY id DESC LIMIT 500"
+        "SELECT ts, session_id, model, event, detail FROM audit ORDER BY id DESC LIMIT ? OFFSET ?",
+        (limit, offset),
     )
     rows = c.fetchall()
     conn.close()
-    return {"events": rows}
+    return {"events": rows, "total": total, "offset": offset, "limit": limit}
 
 
 # ============================================================

--- a/api/config.py
+++ b/api/config.py
@@ -37,9 +37,11 @@ JWT_ALGORITHM = "HS256"
 
 HMAC_SECRET = os.getenv("HMAC_SECRET", "CHANGE_ME_HMAC")
 
+ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "CHANGE_ME_ADMIN")
+
 # Warn loudly if placeholder secrets are in use
-_WEAK_SECRETS = {"CHANGE_ME", "CHANGE_ME_HMAC", "change_me_in_production", "change_me_hmac_in_production"}
-if JWT_SECRET in _WEAK_SECRETS or HMAC_SECRET in _WEAK_SECRETS:
+_WEAK_SECRETS = {"CHANGE_ME", "CHANGE_ME_HMAC", "CHANGE_ME_ADMIN", "change_me_in_production", "change_me_hmac_in_production"}
+if JWT_SECRET in _WEAK_SECRETS or HMAC_SECRET in _WEAK_SECRETS or ADMIN_PASSWORD in _WEAK_SECRETS:
     print("[SECURITY WARNING] JWT_SECRET or HMAC_SECRET is set to a weak default. "
           "Set strong random values in your .env before deploying to production.")
 

--- a/api/services/auth.py
+++ b/api/services/auth.py
@@ -1,6 +1,16 @@
+import datetime
 import jwt
 from fastapi import HTTPException, Header
 from config import JWT_SECRET, JWT_ALGORITHM
+
+
+def create_jwt(payload: dict, expires_minutes: int = 480) -> str:
+    """Mint a signed JWT with an exp claim (default 8 hours)."""
+    data = {
+        **payload,
+        "exp": datetime.datetime.utcnow() + datetime.timedelta(minutes=expires_minutes),
+    }
+    return jwt.encode(data, JWT_SECRET, algorithm=JWT_ALGORITHM)
 
 
 def validate_jwt(token: str) -> bool:

--- a/ui/app/dev/components/AuditPanel.tsx
+++ b/ui/app/dev/components/AuditPanel.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { getAdminAudit } from "@/lib/api";
+import { ChevronRight, ChevronDown } from "lucide-react";
+
+interface Props {
+  token: string;
+  onUnauth: () => void;
+}
+
+type AuditRow = [string, string, string, string, string]; // ts, session_id, model, event, detail
+
+const PAGE_SIZE = 100;
+
+export default function AuditPanel({ token, onUnauth }: Props) {
+  const [rows, setRows] = useState<AuditRow[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
+
+  useEffect(() => {
+    setLoading(true);
+    setExpanded(new Set());
+    getAdminAudit(token, page * PAGE_SIZE, PAGE_SIZE)
+      .then((d) => {
+        setRows(d.events as AuditRow[]);
+        setTotal(d.total);
+      })
+      .catch((e) => { if (e.message === "UNAUTHORIZED") onUnauth(); })
+      .finally(() => setLoading(false));
+  }, [token, page, onUnauth]);
+
+  function toggleExpand(i: number) {
+    setExpanded((prev) => {
+      const s = new Set(prev);
+      s.has(i) ? s.delete(i) : s.add(i);
+      return s;
+    });
+  }
+
+  const start = page * PAGE_SIZE + 1;
+  const end = Math.min((page + 1) * PAGE_SIZE, total);
+
+  return (
+    <div className="space-y-4">
+      {/* Pagination header */}
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span>
+          {total > 0 ? `Showing ${start}–${end} of ${total}` : "No audit events"}
+        </span>
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-7 px-3 text-xs"
+            disabled={page === 0}
+            onClick={() => setPage((p) => p - 1)}
+          >
+            Previous
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-7 px-3 text-xs"
+            disabled={end >= total}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
+
+      {/* Table */}
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs font-mono">
+            <thead>
+              <tr className="border-b border-border text-[11px] text-muted-foreground uppercase">
+                <th className="text-left pb-2 pr-4">Timestamp</th>
+                <th className="text-left pb-2 pr-4">Session</th>
+                <th className="text-left pb-2 pr-4">Model</th>
+                <th className="text-left pb-2 pr-4">Event</th>
+                <th className="text-left pb-2">Detail</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border/50">
+              {rows.map(([ts, sessionId, model, event, detail], i) => {
+                const truncated = detail.length > 60 ? detail.slice(0, 60) + "…" : detail;
+                const needsExpand = detail.length > 60;
+                return (
+                  <>
+                    <tr key={i} className="hover:bg-surface/40">
+                      <td className="py-2 pr-4 text-muted-foreground whitespace-nowrap">{ts}</td>
+                      <td className="py-2 pr-4">
+                        <span title={sessionId}>{sessionId.slice(0, 8)}…</span>
+                      </td>
+                      <td className="py-2 pr-4 text-muted-foreground">{model || "—"}</td>
+                      <td className="py-2 pr-4">
+                        <span className="text-accent">{event}</span>
+                      </td>
+                      <td className="py-2">
+                        <span className="text-muted-foreground">
+                          {needsExpand && !expanded.has(i) ? truncated : detail}
+                        </span>
+                        {needsExpand && (
+                          <button
+                            onClick={() => toggleExpand(i)}
+                            className="ml-1 text-muted-foreground hover:text-foreground inline-flex items-center"
+                          >
+                            {expanded.has(i)
+                              ? <ChevronDown className="h-3 w-3" />
+                              : <ChevronRight className="h-3 w-3" />}
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  </>
+                );
+              })}
+            </tbody>
+          </table>
+          {rows.length === 0 && !loading && (
+            <p className="text-center text-muted-foreground text-sm py-8">No audit events yet.</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/app/dev/components/HealthPanel.tsx
+++ b/ui/app/dev/components/HealthPanel.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { HealthResponse, AdminJobsResponse } from "@/lib/api";
+import { Wifi, WifiOff, Cpu, HardDrive, Server } from "lucide-react";
+
+interface Props {
+  health: HealthResponse | null;
+  queueDepths: AdminJobsResponse["queue_depths"] | null;
+  lastUpdated: Date | null;
+}
+
+export default function HealthPanel({ health, queueDepths, lastUpdated }: Props) {
+  if (!health) {
+    return <div className="text-sm text-muted-foreground">Loading system health…</div>;
+  }
+
+  const memUsedMb = health.mem_total_mb - health.mem_available_mb;
+  const memPct = health.mem_total_mb > 0 ? (memUsedMb / health.mem_total_mb) * 100 : 0;
+  const gpus = Array.isArray(health.gpu_usage) ? health.gpu_usage : [];
+
+  return (
+    <div className="space-y-6">
+      {/* Top stat row */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {/* Redis */}
+        <Card>
+          <CardContent className="pt-5">
+            <div className="flex items-center gap-2 mb-1">
+              {health.redis
+                ? <Wifi className="h-4 w-4 text-success" />
+                : <WifiOff className="h-4 w-4 text-destructive" />}
+              <span className="text-xs text-muted-foreground">Redis</span>
+            </div>
+            <p className={`text-sm font-semibold ${health.redis ? "text-success" : "text-destructive"}`}>
+              {health.redis ? "Connected" : "Down"}
+            </p>
+          </CardContent>
+        </Card>
+
+        {/* CPU */}
+        <Card>
+          <CardContent className="pt-5">
+            <div className="flex items-center gap-2 mb-1">
+              <Cpu className="h-4 w-4 text-muted-foreground" />
+              <span className="text-xs text-muted-foreground">CPU cores</span>
+            </div>
+            <p className="text-sm font-semibold">{health.cpu_count}</p>
+          </CardContent>
+        </Card>
+
+        {/* Memory */}
+        <Card className="col-span-2">
+          <CardContent className="pt-5">
+            <div className="flex items-center gap-2 mb-2">
+              <HardDrive className="h-4 w-4 text-muted-foreground" />
+              <span className="text-xs text-muted-foreground">System memory</span>
+              <span className="ml-auto text-xs text-muted-foreground">
+                {memUsedMb.toFixed(0)} / {health.mem_total_mb.toFixed(0)} MB
+              </span>
+            </div>
+            <Progress value={memPct} className="h-2" />
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* GPU cards */}
+      {gpus.length > 0 && (
+        <div>
+          <h3 className="text-xs font-medium uppercase text-muted-foreground mb-3">GPUs</h3>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {gpus.map((g) => {
+              const vramPct = g.mem_total > 0 ? (g.mem_used / g.mem_total) * 100 : 0;
+              return (
+                <Card key={g.gpu}>
+                  <CardHeader className="pb-2 pt-4 px-4">
+                    <CardTitle className="text-xs text-muted-foreground flex justify-between">
+                      <span>GPU {g.gpu}</span>
+                      <span className="text-foreground font-semibold">{g.util}%</span>
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="px-4 pb-4 space-y-2">
+                    <Progress value={g.util} className="h-1.5" />
+                    <div className="flex justify-between text-[11px] text-muted-foreground">
+                      <span>VRAM</span>
+                      <span>{(g.mem_used / 1024).toFixed(1)} / {(g.mem_total / 1024).toFixed(1)} GB</span>
+                    </div>
+                    <Progress value={vramPct} className="h-1" />
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {typeof health.gpu_usage === "string" && (
+        <p className="text-xs text-muted-foreground">GPU info: {health.gpu_usage}</p>
+      )}
+
+      {/* Queue depths */}
+      {queueDepths && (
+        <div>
+          <h3 className="text-xs font-medium uppercase text-muted-foreground mb-3">Queue depths</h3>
+          <div className="grid grid-cols-3 gap-3">
+            {(
+              [
+                { label: "Segmentation", key: "gpu_seg" as const, color: "text-accent" },
+                { label: "ROAST", key: "roast" as const, color: "text-blue-400" },
+                { label: "SimNIBS", key: "simnibs" as const, color: "text-purple-400" },
+              ] as const
+            ).map(({ label, key, color }) => (
+              <Card key={key}>
+                <CardContent className="pt-4">
+                  <div className="flex items-center gap-2 mb-1">
+                    <Server className="h-3.5 w-3.5 text-muted-foreground" />
+                    <span className="text-xs text-muted-foreground">{label}</span>
+                  </div>
+                  <p className={`text-xl font-bold ${color}`}>{queueDepths[key]}</p>
+                  <p className="text-[11px] text-muted-foreground">queued</p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {lastUpdated && (
+        <p className="text-[11px] text-muted-foreground text-right">
+          Updated {lastUpdated.toLocaleTimeString()}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/ui/app/dev/components/JobsPanel.tsx
+++ b/ui/app/dev/components/JobsPanel.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { AdminJob, cancelJob } from "@/lib/api";
+import { Progress } from "@/components/ui/progress";
+import { Button } from "@/components/ui/button";
+import { XCircle } from "lucide-react";
+import { useState } from "react";
+
+interface Props {
+  jobs: AdminJob[];
+  onRefresh: () => void;
+}
+
+const TYPE_LABEL: Record<AdminJob["type"], string> = {
+  gpu_seg: "Seg",
+  roast: "ROAST",
+  simnibs: "SimNIBS",
+};
+
+const TYPE_COLOR: Record<AdminJob["type"], string> = {
+  gpu_seg: "bg-accent/20 text-accent",
+  roast: "bg-blue-500/20 text-blue-400",
+  simnibs: "bg-purple-500/20 text-purple-400",
+};
+
+function statusBadge(status: string) {
+  const map: Record<string, string> = {
+    queued:      "bg-muted text-muted-foreground",
+    waiting_gpu: "bg-orange-500/20 text-orange-400",
+    running:     "bg-accent/20 text-accent animate-pulse",
+    error:       "bg-destructive/20 text-destructive",
+    cancelled:   "bg-muted text-muted-foreground line-through",
+  };
+  const cls = map[status] ?? "bg-muted text-muted-foreground";
+  return (
+    <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium ${cls}`}>
+      {status}
+    </span>
+  );
+}
+
+export default function JobsPanel({ jobs, onRefresh }: Props) {
+  const [cancelling, setCancelling] = useState<Set<string>>(new Set());
+
+  async function handleCancel(sessionId: string) {
+    setCancelling((prev) => new Set(prev).add(sessionId));
+    try {
+      await cancelJob(sessionId);
+      onRefresh();
+    } finally {
+      setCancelling((prev) => { const s = new Set(prev); s.delete(sessionId); return s; });
+    }
+  }
+
+  if (jobs.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 text-muted-foreground gap-2">
+        <XCircle className="h-8 w-8 opacity-30" />
+        <p className="text-sm">No active jobs</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-border text-xs text-muted-foreground uppercase">
+            <th className="text-left pb-2 pr-4">Type</th>
+            <th className="text-left pb-2 pr-4">Session</th>
+            <th className="text-left pb-2 pr-4">Model</th>
+            <th className="text-left pb-2 pr-4">Status</th>
+            <th className="text-left pb-2 pr-4 w-32">Progress</th>
+            <th className="text-left pb-2 pr-4">GPU</th>
+            <th className="text-left pb-2"></th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {jobs.map((job, i) => (
+            <tr key={i} className="hover:bg-surface/50">
+              <td className="py-2.5 pr-4">
+                <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium ${TYPE_COLOR[job.type]}`}>
+                  {TYPE_LABEL[job.type]}
+                </span>
+              </td>
+              <td className="py-2.5 pr-4 font-mono text-xs">
+                <span title={job.session_id}>{job.session_id.slice(0, 8)}…</span>
+              </td>
+              <td className="py-2.5 pr-4 text-xs text-muted-foreground">{job.model || "—"}</td>
+              <td className="py-2.5 pr-4">{statusBadge(job.status)}</td>
+              <td className="py-2.5 pr-4">
+                <div className="flex items-center gap-2">
+                  <Progress value={job.progress} className="h-1.5 w-24" />
+                  <span className="text-[11px] text-muted-foreground w-8">{Math.round(job.progress)}%</span>
+                </div>
+              </td>
+              <td className="py-2.5 pr-4 text-xs text-muted-foreground">
+                {job.gpu != null ? `GPU ${job.gpu}` : "—"}
+              </td>
+              <td className="py-2.5">
+                {job.status !== "cancelled" && job.status !== "error" && (
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    className="h-6 px-2 text-[11px]"
+                    disabled={cancelling.has(job.session_id)}
+                    onClick={() => handleCancel(job.session_id)}
+                  >
+                    Cancel
+                  </Button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/ui/app/dev/components/LoginGate.tsx
+++ b/ui/app/dev/components/LoginGate.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { adminLogin } from "@/lib/api";
+import { ShieldCheck } from "lucide-react";
+
+interface Props {
+  onLogin: (token: string) => void;
+}
+
+export default function LoginGate({ onLogin }: Props) {
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const { token } = await adminLogin(password);
+      localStorage.setItem("admin_token", token);
+      onLogin(token);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Login failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center pb-4">
+          <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-accent/15">
+            <ShieldCheck className="h-6 w-6 text-accent" />
+          </div>
+          <CardTitle className="text-lg">Admin Access</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Input
+              type="password"
+              placeholder="Admin password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              autoFocus
+            />
+            {error && (
+              <p className="text-sm text-destructive">{error}</p>
+            )}
+            <Button type="submit" className="w-full" disabled={loading || !password}>
+              {loading ? "Signing in…" : "Sign in"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/ui/app/dev/page.tsx
+++ b/ui/app/dev/page.tsx
@@ -1,90 +1,155 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { getHealth, getAdminJobs, HealthResponse, AdminJobsResponse } from "@/lib/api";
+import LoginGate from "./components/LoginGate";
+import HealthPanel from "./components/HealthPanel";
+import JobsPanel from "./components/JobsPanel";
+import LogsPanel from "./components/LogsPanel";
+import AuditPanel from "./components/AuditPanel";
+import { LogOut, RefreshCw } from "lucide-react";
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://10.15.224.253:8100";
-
-interface Session {
-  session_id: string;
-  has_logs: boolean;
-  created: number;
+function isTokenExpired(token: string): boolean {
+  try {
+    const payload = JSON.parse(atob(token.split(".")[1]));
+    return payload.exp * 1000 < Date.now();
+  } catch {
+    return true;
+  }
 }
 
-export default function LogsPage() {
-  const [sessions, setSessions] = useState<Session[]>([]);
-  const [selectedSession, setSelectedSession] = useState<string | null>(null);
-  const [logs, setLogs] = useState<string>("");
-  const [error, setError] = useState<string | null>(null);
+export default function AdminPage() {
+  const [token, setToken] = useState<string | null>(null);
+  const [health, setHealth] = useState<HealthResponse | null>(null);
+  const [jobsData, setJobsData] = useState<AdminJobsResponse | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
+  // Restore token from localStorage on mount
   useEffect(() => {
-    fetch(`${API_BASE}/logs`)
-      .then((res) => res.json())
-      .then((data) => setSessions(data.sessions))
-      .catch((err) => setError(err.message));
+    const stored = localStorage.getItem("admin_token");
+    if (stored && !isTokenExpired(stored)) {
+      setToken(stored);
+    } else {
+      localStorage.removeItem("admin_token");
+    }
   }, []);
 
+  function handleUnauth() {
+    localStorage.removeItem("admin_token");
+    setToken(null);
+  }
+
+  async function fetchData(t: string) {
+    try {
+      const [h, j] = await Promise.all([getHealth(), getAdminJobs(t)]);
+      setHealth(h);
+      setJobsData(j);
+      setLastUpdated(new Date());
+    } catch (e: unknown) {
+      if (e instanceof Error && e.message === "UNAUTHORIZED") handleUnauth();
+    }
+  }
+
+  async function manualRefresh() {
+    if (!token) return;
+    setRefreshing(true);
+    await fetchData(token);
+    setRefreshing(false);
+  }
+
+  // Poll every 5 seconds while authenticated
   useEffect(() => {
-    if (!selectedSession) {
-      setLogs("");
+    if (!token) {
+      if (intervalRef.current) clearInterval(intervalRef.current);
       return;
     }
+    fetchData(token);
+    intervalRef.current = setInterval(() => fetchData(token), 5000);
+    return () => { if (intervalRef.current) clearInterval(intervalRef.current); };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]);
 
-    fetch(`${API_BASE}/logs/${selectedSession}`)
-      .then((res) => {
-        if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-        return res.text();
-      })
-      .then(setLogs)
-      .catch((err) => setLogs(`Error: ${err.message}`));
-  }, [selectedSession]);
-
-  const formatDate = (ts: number) => {
-    return new Date(ts * 1000).toLocaleString();
-  };
+  if (!token) {
+    return <LoginGate onLogin={setToken} />;
+  }
 
   return (
-    <div className="min-h-screen bg-black text-white p-6 font-mono text-sm">
-      <h1 className="text-xl font-bold mb-6">Session Logs</h1>
-
-      {error && <div className="text-red-400 mb-4">Error: {error}</div>}
-
-      <div className="flex gap-6">
-        {/* Session list */}
-        <div className="w-80 shrink-0">
-          <div className="text-neutral-400 text-xs uppercase mb-2">Sessions ({sessions.length})</div>
-          <div className="space-y-1 max-h-[80vh] overflow-y-auto">
-            {sessions.map((s) => (
-              <button
-                key={s.session_id}
-                onClick={() => setSelectedSession(s.session_id)}
-                className={`w-full text-left px-3 py-2 rounded text-xs ${
-                  selectedSession === s.session_id
-                    ? "bg-amber-600 text-white"
-                    : "bg-neutral-900 hover:bg-neutral-800"
-                }`}
-              >
-                <div className="truncate">{s.session_id}</div>
-                <div className="text-neutral-400 text-[10px]">{formatDate(s.created)}</div>
-              </button>
-            ))}
+    <div className="min-h-screen bg-background">
+      <div className="max-w-7xl mx-auto px-4 py-6">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <h1 className="text-xl font-bold">Admin</h1>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {jobsData ? `${jobsData.jobs.length} active job${jobsData.jobs.length !== 1 ? "s" : ""}` : "Loading…"}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-8 gap-1.5 text-xs"
+              onClick={manualRefresh}
+              disabled={refreshing}
+            >
+              <RefreshCw className={`h-3.5 w-3.5 ${refreshing ? "animate-spin" : ""}`} />
+              Refresh
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-8 gap-1.5 text-xs text-muted-foreground"
+              onClick={handleUnauth}
+            >
+              <LogOut className="h-3.5 w-3.5" />
+              Sign out
+            </Button>
           </div>
         </div>
 
-        {/* Logs panel */}
-        <div className="flex-1 min-w-0">
-          {selectedSession ? (
-            <>
-              <div className="text-neutral-400 text-xs uppercase mb-2">
-                Logs: {selectedSession}
-              </div>
-              <pre className="whitespace-pre-wrap break-words bg-neutral-900 p-4 rounded max-h-[80vh] overflow-y-auto">
-                {logs || "Loading..."}
-              </pre>
-            </>
-          ) : (
-            <div className="text-neutral-500">Select a session to view logs</div>
-          )}
-        </div>
+        {/* Tabs */}
+        <Tabs defaultValue="overview">
+          <TabsList className="mb-6">
+            <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="jobs">
+              Live Jobs
+              {jobsData && jobsData.jobs.length > 0 && (
+                <span className="ml-1.5 rounded-full bg-accent text-background text-[10px] font-bold px-1.5 py-0.5 leading-none">
+                  {jobsData.jobs.length}
+                </span>
+              )}
+            </TabsTrigger>
+            <TabsTrigger value="logs">Logs</TabsTrigger>
+            <TabsTrigger value="audit">Audit</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="overview">
+            <HealthPanel
+              health={health}
+              queueDepths={jobsData?.queue_depths ?? null}
+              lastUpdated={lastUpdated}
+            />
+          </TabsContent>
+
+          <TabsContent value="jobs">
+            <JobsPanel
+              jobs={jobsData?.jobs ?? []}
+              onRefresh={() => token && fetchData(token)}
+            />
+          </TabsContent>
+
+          <TabsContent value="logs">
+            <LogsPanel token={token} onUnauth={handleUnauth} />
+          </TabsContent>
+
+          <TabsContent value="audit">
+            <AuditPanel token={token} onUnauth={handleUnauth} />
+          </TabsContent>
+        </Tabs>
       </div>
     </div>
   );

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -405,6 +405,117 @@ export async function cancelJob(sessionId: string): Promise<void> {
 }
 
 // ---------------------------------------------------------------------
+// ADMIN — types
+// ---------------------------------------------------------------------
+export interface AdminJob {
+  type: "gpu_seg" | "roast" | "simnibs";
+  session_id: string;
+  model: string;
+  run_id: string | null;
+  status: string;
+  progress: number;
+  gpu: string | null;
+}
+
+export interface AdminJobsResponse {
+  jobs: AdminJob[];
+  queue_depths: { gpu_seg: number; roast: number; simnibs: number };
+}
+
+export interface AuditResponse {
+  events: [string, string, string, string, string][];
+  total: number;
+  offset: number;
+  limit: number;
+}
+
+export interface SessionMeta {
+  session_id: string;
+  has_logs: boolean;
+  created: number;
+}
+
+function authHeader(token: string): HeadersInit {
+  return { Authorization: `Bearer ${token}` };
+}
+
+// ---------------------------------------------------------------------
+// POST /admin/login
+// ---------------------------------------------------------------------
+export async function adminLogin(password: string): Promise<{ token: string }> {
+  const res = await fetch(`${API_BASE}/admin/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ password }),
+  });
+  if (!res.ok) {
+    let detail = "Login failed";
+    try { const err = await res.json(); detail = err.detail || detail; } catch {}
+    throw new Error(detail);
+  }
+  return res.json();
+}
+
+// ---------------------------------------------------------------------
+// GET /admin/jobs
+// ---------------------------------------------------------------------
+export async function getAdminJobs(token: string): Promise<AdminJobsResponse> {
+  const res = await fetch(`${API_BASE}/admin/jobs`, { headers: authHeader(token) });
+  if (res.status === 401) throw new Error("UNAUTHORIZED");
+  if (!res.ok) throw new Error("Failed to fetch jobs");
+  return res.json();
+}
+
+// ---------------------------------------------------------------------
+// GET /admin/audit
+// ---------------------------------------------------------------------
+export async function getAdminAudit(
+  token: string,
+  offset = 0,
+  limit = 100,
+): Promise<AuditResponse> {
+  const res = await fetch(
+    `${API_BASE}/admin/audit?offset=${offset}&limit=${limit}`,
+    { headers: authHeader(token) },
+  );
+  if (res.status === 401) throw new Error("UNAUTHORIZED");
+  if (!res.ok) throw new Error("Failed to fetch audit log");
+  return res.json();
+}
+
+// ---------------------------------------------------------------------
+// GET /logs  — list sessions (admin)
+// ---------------------------------------------------------------------
+export async function adminListSessions(token: string): Promise<{ sessions: SessionMeta[] }> {
+  const res = await fetch(`${API_BASE}/logs`, { headers: authHeader(token) });
+  if (res.status === 401) throw new Error("UNAUTHORIZED");
+  if (!res.ok) throw new Error("Failed to list sessions");
+  return res.json();
+}
+
+// ---------------------------------------------------------------------
+// GET /admin/logs/{session_id}  — raw JSONL text
+// ---------------------------------------------------------------------
+export async function adminGetLogs(token: string, sessionId: string): Promise<string> {
+  const res = await fetch(`${API_BASE}/admin/logs/${sessionId}`, {
+    headers: authHeader(token),
+  });
+  if (res.status === 401) throw new Error("UNAUTHORIZED");
+  if (!res.ok) throw new Error(`No logs for ${sessionId}`);
+  return res.text();
+}
+
+// ---------------------------------------------------------------------
+// DELETE /session/{session_id}  — admin delete with auth
+// ---------------------------------------------------------------------
+export async function adminDeleteSession(token: string, sessionId: string): Promise<void> {
+  await fetch(`${API_BASE}/session/${sessionId}`, {
+    method: "DELETE",
+    headers: authHeader(token),
+  });
+}
+
+// ---------------------------------------------------------------------
 // GET /health
 // ---------------------------------------------------------------------
 export async function getHealth(): Promise<HealthResponse> {


### PR DESCRIPTION
Backend:
- config.py: add ADMIN_PASSWORD env var
- services/auth.py: add create_jwt() for minting 8-hour tokens
- app.py: POST /admin/login (password → JWT), GET /admin/jobs (Redis scan across all 3 schedulers), GET /admin/audit now paginated with offset/limit

Frontend (ui/app/dev/):
- LoginGate: password form → JWT stored in localStorage
- page.tsx: auth-gated shell, 4 tabs, 5-second polling loop, auto-logout on 401
- HealthPanel: GPU utilisation cards, Redis status, memory bar, queue depths
- JobsPanel: table of active jobs with type/status badges, progress bars, cancel
- LogsPanel: session selector + JSONL parser with level filter, search, extra expand
- AuditPanel: paginated audit event table with detail expand