### PR TITLE
fix: per-phase SimNIBS timeouts + browser back guard on TES page

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -75,7 +75,7 @@ ROAST_TIMEOUT_SECONDS = int(os.getenv("ROAST_TIMEOUT_SECONDS", "7200"))
 # SIMNIBS CONFIG
 # -------------------------------------------------------
 SIMNIBS_MAX_WORKERS = int(os.getenv("SIMNIBS_MAX_WORKERS", "2"))
-SIMNIBS_TIMEOUT_SECONDS = int(os.getenv("SIMNIBS_TIMEOUT_SECONDS", "7200"))
+SIMNIBS_TIMEOUT_SECONDS = int(os.getenv("SIMNIBS_TIMEOUT_SECONDS", "14400"))  # 4 h per phase
 # Path to SimNIBS installation directory (contains bin/charm, bin/simnibs, etc.)
 # Set SIMNIBS_HOME in .env to e.g. /home/chintan/SimNIBS-4 or /usr/local/simnibs
 SIMNIBS_HOME = os.getenv("SIMNIBS_HOME", "") or os.getenv("SIM_NIBS", "/opt/simnibs")

--- a/api/runtime/simnibs_runner.py
+++ b/api/runtime/simnibs_runner.py
@@ -621,10 +621,9 @@ class SimNIBSRunner:
           5. Save remapped labels as custom_tissues.nii.gz for post-processing.
           6. Run meshmesh to build the FEM mesh from custom labels.
         """
-        deadline = time.time() + SIMNIBS_TIMEOUT_SECONDS
         self._emit("simnibs_charm", 5)
 
-        # Step 1 — shared --initatlas base (fast, ~30s)
+        # Step 1 — shared --initatlas base (fast, ~30s); has its own internal deadline
         base_m2m = self._ensure_initatlas_base()
         self._emit("simnibs_charm_register", 12)
 
@@ -644,9 +643,11 @@ class SimNIBSRunner:
             content = content.replace(base_work_str, model_work_str)
             settings_file.write_text(content)
 
-        # Step 4 — inject DL labels + charm --surfaces --mesh (per model)
+        # Step 4 — inject DL labels + charm --surfaces --mesh (per model).
+        # Fresh deadline: surfaces + mesh together can take ~60–90 min.
         self._emit("simnibs_charm_surface", 15)
-        self._inject_labels_and_run_charm(model_m2m, seg_path, deadline)
+        surfaces_deadline = time.time() + SIMNIBS_TIMEOUT_SECONDS
+        self._inject_labels_and_run_charm(model_m2m, seg_path, surfaces_deadline)
         self._emit("simnibs_charm_done", 55)
 
         # Step 5 — save custom labels as custom_tissues.nii.gz for post-processing
@@ -654,12 +655,12 @@ class SimNIBSRunner:
         shutil.copy2(str(seg_path), str(custom_tissues))
         session_log(self.session_id, f"[SimNIBS] Custom labels → {custom_tissues}")
 
-        # Step 6 — meshmesh
+        # Step 6 — meshmesh (fresh deadline)
         custom_mesh = self.work_dir / f"{SUBJECT}_custom_mesh.msh"
         self._emit("simnibs_charm_mesh", 58)
         session_log(self.session_id, "[SimNIBS] meshmesh: building FEM mesh from custom labels…")
         cmd = _meshmesh_cmd() + [str(seg_path), str(custom_mesh), "--voxsize_meshing", "0.5"]
-        self._run_proc(cmd, "meshmesh", self.work_dir, deadline)
+        self._run_proc(cmd, "meshmesh", self.work_dir, time.time() + SIMNIBS_TIMEOUT_SECONDS)
 
         if not custom_mesh.exists():
             raise FileNotFoundError(f"meshmesh did not produce expected mesh: {custom_mesh}")

--- a/ui/app/components/tes/TESPage.tsx
+++ b/ui/app/components/tes/TESPage.tsx
@@ -246,15 +246,39 @@ export default function TESPage() {
     pendingLeaveRef.current = () => router.back();
   }, [router]);
 
-  // Attach beforeunload for tab/window close
+  // Guard both browser back (popstate) and tab/window close (beforeunload).
+  // Next.js App Router handles back-button as client-side popstate navigation,
+  // so beforeunload alone does not intercept it.
   useEffect(() => {
-    const handler = (e: BeforeUnloadEvent) => {
+    // Push a duplicate history entry so the first back-press lands here
+    // instead of immediately leaving; we then show the modal.
+    window.history.pushState(null, "", window.location.href);
+
+    const onPopState = () => {
+      // Re-push to stay on this page, then open the guard modal.
+      window.history.pushState(null, "", window.location.href);
+      setLeaveGuardOpen(true);
+      pendingLeaveRef.current = () => {
+        // Remove listener before navigating so we don't loop.
+        window.removeEventListener("popstate", onPopState);
+        router.back();
+        // back() will pop twice: our synthetic entry + the real one.
+        router.back();
+      };
+    };
+
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
       e.preventDefault();
       e.returnValue = "";
     };
-    window.addEventListener("beforeunload", handler);
-    return () => window.removeEventListener("beforeunload", handler);
-  }, []);
+
+    window.addEventListener("popstate", onPopState);
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => {
+      window.removeEventListener("popstate", onPopState);
+      window.removeEventListener("beforeunload", onBeforeUnload);
+    };
+  }, [router]);
 
   // ── Reconnect state (for page-refresh recovery) ───────────────────────────
   type ReconnectStatus = "checking" | "running" | "complete" | "none";


### PR DESCRIPTION
simnibs_runner: each pipeline phase (surfaces+mesh, meshmesh, FEM solve) now gets its own fresh SIMNIBS_TIMEOUT_SECONDS deadline instead of sharing one from build_mesh start — prevents spurious timeouts on hour-long runs. Default increased 7200→14400s (4 h per phase).

TESPage: replace unconditional beforeunload with popstate+beforeunload combo. Pushes a synthetic history entry on mount so the browser back button fires popstate (client-side) rather than silently navigating away. popstate handler re-pushes the entry and opens LeaveGuardModal; user must confirm before leaving.