### PR TITLE
fix(admin): filter stale jobs + redesign dashboard UI

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -751,6 +751,7 @@ async def admin_login(body: dict = Body(...)):
 # ============================================================
 @app.get("/admin/jobs")
 def get_admin_jobs(_: str = Depends(require_jwt)):
+    ACTIVE_STATUSES = {"queued", "waiting_gpu", "assigned", "running"}
     jobs = []
 
     # GPU locks: HASH  gpu_id → "free" | "{session_id}:{model}"
@@ -762,7 +763,7 @@ def get_admin_jobs(_: str = Depends(require_jwt)):
         session_id = key[len("job_status:"):]
         model_statuses = redis_client.hgetall(key)
         for model, status in model_statuses.items():
-            if status == "complete":
+            if status not in ACTIVE_STATUSES:
                 continue
             progress_raw = redis_client.hget("progress", f"{session_id}:{model}")
             progress = float(progress_raw) if progress_raw else 0.0
@@ -788,7 +789,7 @@ def get_admin_jobs(_: str = Depends(require_jwt)):
         model = parts[1] if len(parts) > 1 else ""
         run_id = parts[2] if len(parts) > 2 else ""
         status = redis_client.get(key) or "unknown"
-        if status == "complete":
+        if status not in ACTIVE_STATUSES:
             continue
         progress_raw = redis_client.get(f"roast_progress:{suffix}")
         progress = float(progress_raw) if progress_raw else 0.0
@@ -810,7 +811,7 @@ def get_admin_jobs(_: str = Depends(require_jwt)):
         model = parts[1] if len(parts) > 1 else ""
         run_id = parts[2] if len(parts) > 2 else ""
         status = redis_client.get(key) or "unknown"
-        if status == "complete":
+        if status not in ACTIVE_STATUSES:
             continue
         progress_raw = redis_client.get(f"simnibs_progress:{suffix}")
         progress = float(progress_raw) if progress_raw else 0.0

--- a/ui/app/dev/components/AuditPanel.tsx
+++ b/ui/app/dev/components/AuditPanel.tsx
@@ -45,10 +45,10 @@ export default function AuditPanel({ token, onUnauth }: Props) {
   const end = Math.min((page + 1) * PAGE_SIZE, total);
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 animate-fade-in">
       {/* Pagination header */}
-      <div className="flex items-center justify-between text-xs text-muted-foreground">
-        <span>
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-foreground-muted">
           {total > 0 ? `Showing ${start}–${end} of ${total}` : "No audit events"}
         </span>
         <div className="flex gap-2">
@@ -75,58 +75,62 @@ export default function AuditPanel({ token, onUnauth }: Props) {
 
       {/* Table */}
       {loading ? (
-        <p className="text-sm text-muted-foreground">Loading…</p>
+        <p className="text-sm text-foreground-muted py-8 text-center">Loading…</p>
       ) : (
-        <div className="overflow-x-auto">
-          <table className="w-full text-xs font-mono">
-            <thead>
-              <tr className="border-b border-border text-[11px] text-muted-foreground uppercase">
-                <th className="text-left pb-2 pr-4">Timestamp</th>
-                <th className="text-left pb-2 pr-4">Session</th>
-                <th className="text-left pb-2 pr-4">Model</th>
-                <th className="text-left pb-2 pr-4">Event</th>
-                <th className="text-left pb-2">Detail</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border/50">
-              {rows.map(([ts, sessionId, model, event, detail], i) => {
-                const truncated = detail.length > 60 ? detail.slice(0, 60) + "…" : detail;
-                const needsExpand = detail.length > 60;
-                return (
-                  <>
-                    <tr key={i} className="hover:bg-surface/40">
-                      <td className="py-2 pr-4 text-muted-foreground whitespace-nowrap">{ts}</td>
-                      <td className="py-2 pr-4">
-                        <span title={sessionId}>{sessionId.slice(0, 8)}…</span>
+        <div className="bg-surface border border-border rounded-xl shadow-medical-lg overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm font-mono">
+              <thead>
+                <tr className="border-b border-border bg-surface-elevated/50">
+                  <th className="text-left py-3 px-4 text-xs font-semibold uppercase tracking-wider text-foreground-muted font-sans">Timestamp</th>
+                  <th className="text-left py-3 px-4 text-xs font-semibold uppercase tracking-wider text-foreground-muted font-sans">Session</th>
+                  <th className="text-left py-3 px-4 text-xs font-semibold uppercase tracking-wider text-foreground-muted font-sans">Model</th>
+                  <th className="text-left py-3 px-4 text-xs font-semibold uppercase tracking-wider text-foreground-muted font-sans">Event</th>
+                  <th className="text-left py-3 px-4 text-xs font-semibold uppercase tracking-wider text-foreground-muted font-sans">Detail</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map(([ts, sessionId, model, event, detail], i) => {
+                  const truncated = detail.length > 60 ? detail.slice(0, 60) + "…" : detail;
+                  const needsExpand = detail.length > 60;
+                  return (
+                    <tr key={i} className="border-b border-border/50 hover:bg-surface-elevated/40 transition-colors">
+                      <td className="py-2.5 px-4 text-xs text-foreground-muted whitespace-nowrap">{ts}</td>
+                      <td className="py-2.5 px-4 text-xs">
+                        <span title={sessionId} className="text-foreground-secondary">{sessionId.slice(0, 8)}</span>
                       </td>
-                      <td className="py-2 pr-4 text-muted-foreground">{model || "—"}</td>
-                      <td className="py-2 pr-4">
-                        <span className="text-accent">{event}</span>
-                      </td>
-                      <td className="py-2">
-                        <span className="text-muted-foreground">
-                          {needsExpand && !expanded.has(i) ? truncated : detail}
+                      <td className="py-2.5 px-4 text-xs text-foreground-muted">{model || "—"}</td>
+                      <td className="py-2.5 px-4">
+                        <span className="inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium bg-accent/15 text-accent border border-accent/25">
+                          {event}
                         </span>
-                        {needsExpand && (
-                          <button
-                            onClick={() => toggleExpand(i)}
-                            className="ml-1 text-muted-foreground hover:text-foreground inline-flex items-center"
-                          >
-                            {expanded.has(i)
-                              ? <ChevronDown className="h-3 w-3" />
-                              : <ChevronRight className="h-3 w-3" />}
-                          </button>
-                        )}
+                      </td>
+                      <td className="py-2.5 px-4">
+                        <div className="flex items-center gap-1.5">
+                          <span className="text-xs text-foreground-muted">
+                            {needsExpand && !expanded.has(i) ? truncated : detail}
+                          </span>
+                          {needsExpand && (
+                            <button
+                              onClick={() => toggleExpand(i)}
+                              className="text-foreground-muted hover:text-foreground transition-colors shrink-0"
+                            >
+                              {expanded.has(i)
+                                ? <ChevronDown className="h-3.5 w-3.5" />
+                                : <ChevronRight className="h-3.5 w-3.5" />}
+                            </button>
+                          )}
+                        </div>
                       </td>
                     </tr>
-                  </>
-                );
-              })}
-            </tbody>
-          </table>
-          {rows.length === 0 && !loading && (
-            <p className="text-center text-muted-foreground text-sm py-8">No audit events yet.</p>
-          )}
+                  );
+                })}
+              </tbody>
+            </table>
+            {rows.length === 0 && !loading && (
+              <p className="text-center text-foreground-muted text-sm py-12">No audit events yet.</p>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/ui/app/dev/components/HealthPanel.tsx
+++ b/ui/app/dev/components/HealthPanel.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { HealthResponse, AdminJobsResponse } from "@/lib/api";
-import { Wifi, WifiOff, Cpu, HardDrive, Server } from "lucide-react";
+import { Wifi, WifiOff, Cpu, HardDrive, Server, Activity } from "lucide-react";
 
 interface Props {
   health: HealthResponse | null;
@@ -11,9 +10,26 @@ interface Props {
   lastUpdated: Date | null;
 }
 
+function utilColor(pct: number): string {
+  if (pct < 50) return "text-success";
+  if (pct < 80) return "text-warning";
+  return "text-error";
+}
+
+function utilBg(pct: number): string {
+  if (pct < 50) return "bg-success/10 border-success/20";
+  if (pct < 80) return "bg-warning/10 border-warning/20";
+  return "bg-error/10 border-error/20";
+}
+
 export default function HealthPanel({ health, queueDepths, lastUpdated }: Props) {
   if (!health) {
-    return <div className="text-sm text-muted-foreground">Loading system health…</div>;
+    return (
+      <div className="flex items-center justify-center py-20 text-muted-foreground text-sm">
+        <Activity className="h-4 w-4 mr-2 animate-pulse" />
+        Loading system health…
+      </div>
+    );
   }
 
   const memUsedMb = health.mem_total_mb - health.mem_available_mb;
@@ -21,74 +37,102 @@ export default function HealthPanel({ health, queueDepths, lastUpdated }: Props)
   const gpus = Array.isArray(health.gpu_usage) ? health.gpu_usage : [];
 
   return (
-    <div className="space-y-6">
-      {/* Top stat row */}
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+    <div className="space-y-8 animate-fade-in">
+      {/* System stats */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
         {/* Redis */}
-        <Card>
-          <CardContent className="pt-5">
-            <div className="flex items-center gap-2 mb-1">
+        <div className="bg-surface border border-border rounded-xl p-5 shadow-medical-lg">
+          <div className="flex items-center gap-3 mb-3">
+            <div className={`p-2 rounded-lg ${health.redis ? "bg-success/10" : "bg-error/10"}`}>
               {health.redis
                 ? <Wifi className="h-4 w-4 text-success" />
-                : <WifiOff className="h-4 w-4 text-destructive" />}
-              <span className="text-xs text-muted-foreground">Redis</span>
+                : <WifiOff className="h-4 w-4 text-error" />}
             </div>
-            <p className={`text-sm font-semibold ${health.redis ? "text-success" : "text-destructive"}`}>
+            <span className="text-sm text-foreground-secondary">Redis</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className={`h-2 w-2 rounded-full ${health.redis ? "bg-success animate-pulse" : "bg-error"}`} />
+            <span className={`text-lg font-semibold ${health.redis ? "text-success" : "text-error"}`}>
               {health.redis ? "Connected" : "Down"}
-            </p>
-          </CardContent>
-        </Card>
+            </span>
+          </div>
+        </div>
 
         {/* CPU */}
-        <Card>
-          <CardContent className="pt-5">
-            <div className="flex items-center gap-2 mb-1">
-              <Cpu className="h-4 w-4 text-muted-foreground" />
-              <span className="text-xs text-muted-foreground">CPU cores</span>
+        <div className="bg-surface border border-border rounded-xl p-5 shadow-medical-lg">
+          <div className="flex items-center gap-3 mb-3">
+            <div className="p-2 rounded-lg bg-blue-500/10">
+              <Cpu className="h-4 w-4 text-blue-400" />
             </div>
-            <p className="text-sm font-semibold">{health.cpu_count}</p>
-          </CardContent>
-        </Card>
+            <span className="text-sm text-foreground-secondary">CPU Cores</span>
+          </div>
+          <span className="text-2xl font-bold text-foreground">{health.cpu_count}</span>
+        </div>
 
         {/* Memory */}
-        <Card className="col-span-2">
-          <CardContent className="pt-5">
-            <div className="flex items-center gap-2 mb-2">
-              <HardDrive className="h-4 w-4 text-muted-foreground" />
-              <span className="text-xs text-muted-foreground">System memory</span>
-              <span className="ml-auto text-xs text-muted-foreground">
-                {memUsedMb.toFixed(0)} / {health.mem_total_mb.toFixed(0)} MB
-              </span>
+        <div className="bg-surface border border-border rounded-xl p-5 shadow-medical-lg">
+          <div className="flex items-center gap-3 mb-3">
+            <div className={`p-2 rounded-lg ${utilBg(memPct)}`}>
+              <HardDrive className={`h-4 w-4 ${utilColor(memPct)}`} />
             </div>
-            <Progress value={memPct} className="h-2" />
-          </CardContent>
-        </Card>
+            <span className="text-sm text-foreground-secondary">System Memory</span>
+          </div>
+          <div className="flex items-baseline gap-2 mb-3">
+            <span className={`text-2xl font-bold ${utilColor(memPct)}`}>{Math.round(memPct)}%</span>
+            <span className="text-xs text-foreground-muted">
+              {(memUsedMb / 1024).toFixed(1)} / {(health.mem_total_mb / 1024).toFixed(1)} GB
+            </span>
+          </div>
+          <Progress value={memPct} className="h-2" />
+        </div>
       </div>
 
-      {/* GPU cards */}
+      {/* GPUs */}
       {gpus.length > 0 && (
         <div>
-          <h3 className="text-xs font-medium uppercase text-muted-foreground mb-3">GPUs</h3>
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-foreground-muted mb-4">GPUs</h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
             {gpus.map((g) => {
               const vramPct = g.mem_total > 0 ? (g.mem_used / g.mem_total) * 100 : 0;
               return (
-                <Card key={g.gpu}>
-                  <CardHeader className="pb-2 pt-4 px-4">
-                    <CardTitle className="text-xs text-muted-foreground flex justify-between">
-                      <span>GPU {g.gpu}</span>
-                      <span className="text-foreground font-semibold">{g.util}%</span>
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="px-4 pb-4 space-y-2">
-                    <Progress value={g.util} className="h-1.5" />
-                    <div className="flex justify-between text-[11px] text-muted-foreground">
-                      <span>VRAM</span>
-                      <span>{(g.mem_used / 1024).toFixed(1)} / {(g.mem_total / 1024).toFixed(1)} GB</span>
+                <div
+                  key={g.gpu}
+                  className="bg-surface border border-border rounded-xl p-4 shadow-medical-lg hover:shadow-glow transition-shadow duration-300"
+                >
+                  <div className="flex items-center justify-between mb-4">
+                    <span className="text-sm font-medium text-foreground">GPU {g.gpu}</span>
+                    <span className={`text-lg font-bold ${utilColor(g.util)}`}>{g.util}%</span>
+                  </div>
+                  <div className="space-y-3">
+                    <div>
+                      <div className="flex justify-between text-[11px] text-foreground-muted mb-1.5">
+                        <span>Utilization</span>
+                      </div>
+                      <div className="h-2 bg-surface-elevated rounded-full overflow-hidden">
+                        <div
+                          className={`h-full rounded-full transition-all duration-500 ${
+                            g.util < 50 ? "bg-success" : g.util < 80 ? "bg-warning" : "bg-error"
+                          }`}
+                          style={{ width: `${g.util}%` }}
+                        />
+                      </div>
                     </div>
-                    <Progress value={vramPct} className="h-1" />
-                  </CardContent>
-                </Card>
+                    <div>
+                      <div className="flex justify-between text-[11px] text-foreground-muted mb-1.5">
+                        <span>VRAM</span>
+                        <span>{(g.mem_used / 1024).toFixed(1)} / {(g.mem_total / 1024).toFixed(1)} GB</span>
+                      </div>
+                      <div className="h-1.5 bg-surface-elevated rounded-full overflow-hidden">
+                        <div
+                          className={`h-full rounded-full transition-all duration-500 ${
+                            vramPct < 50 ? "bg-blue-400" : vramPct < 80 ? "bg-amber-400" : "bg-red-400"
+                          }`}
+                          style={{ width: `${vramPct}%` }}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
               );
             })}
           </div>
@@ -96,38 +140,36 @@ export default function HealthPanel({ health, queueDepths, lastUpdated }: Props)
       )}
 
       {typeof health.gpu_usage === "string" && (
-        <p className="text-xs text-muted-foreground">GPU info: {health.gpu_usage}</p>
+        <p className="text-xs text-foreground-muted">GPU info: {health.gpu_usage}</p>
       )}
 
       {/* Queue depths */}
       {queueDepths && (
         <div>
-          <h3 className="text-xs font-medium uppercase text-muted-foreground mb-3">Queue depths</h3>
-          <div className="grid grid-cols-3 gap-3">
-            {(
-              [
-                { label: "Segmentation", key: "gpu_seg" as const, color: "text-accent" },
-                { label: "ROAST", key: "roast" as const, color: "text-blue-400" },
-                { label: "SimNIBS", key: "simnibs" as const, color: "text-purple-400" },
-              ] as const
-            ).map(({ label, key, color }) => (
-              <Card key={key}>
-                <CardContent className="pt-4">
-                  <div className="flex items-center gap-2 mb-1">
-                    <Server className="h-3.5 w-3.5 text-muted-foreground" />
-                    <span className="text-xs text-muted-foreground">{label}</span>
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-foreground-muted mb-4">Queue Depths</h3>
+          <div className="grid grid-cols-3 gap-4">
+            {([
+              { label: "Segmentation", key: "gpu_seg" as const, color: "text-accent", bg: "bg-accent/10 border-accent/20", icon: "bg-accent/10" },
+              { label: "ROAST", key: "roast" as const, color: "text-blue-400", bg: "bg-blue-500/10 border-blue-500/20", icon: "bg-blue-500/10" },
+              { label: "SimNIBS", key: "simnibs" as const, color: "text-purple-400", bg: "bg-purple-500/10 border-purple-500/20", icon: "bg-purple-500/10" },
+            ] as const).map(({ label, key, color, bg, icon }) => (
+              <div key={key} className={`rounded-xl border p-5 shadow-medical-lg ${bg}`}>
+                <div className="flex items-center gap-3 mb-3">
+                  <div className={`p-2 rounded-lg ${icon}`}>
+                    <Server className={`h-4 w-4 ${color}`} />
                   </div>
-                  <p className={`text-xl font-bold ${color}`}>{queueDepths[key]}</p>
-                  <p className="text-[11px] text-muted-foreground">queued</p>
-                </CardContent>
-              </Card>
+                  <span className="text-sm text-foreground-secondary">{label}</span>
+                </div>
+                <p className={`text-3xl font-bold ${color}`}>{queueDepths[key]}</p>
+                <p className="text-xs text-foreground-muted mt-1">in queue</p>
+              </div>
             ))}
           </div>
         </div>
       )}
 
       {lastUpdated && (
-        <p className="text-[11px] text-muted-foreground text-right">
+        <p className="text-[11px] text-foreground-muted text-right">
           Updated {lastUpdated.toLocaleTimeString()}
         </p>
       )}

--- a/ui/app/dev/components/JobsPanel.tsx
+++ b/ui/app/dev/components/JobsPanel.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { AdminJob, cancelJob } from "@/lib/api";
-import { Progress } from "@/components/ui/progress";
 import { Button } from "@/components/ui/button";
-import { XCircle } from "lucide-react";
+import { XCircle, Inbox } from "lucide-react";
 import { useState } from "react";
 
 interface Props {
@@ -17,27 +16,29 @@ const TYPE_LABEL: Record<AdminJob["type"], string> = {
   simnibs: "SimNIBS",
 };
 
-const TYPE_COLOR: Record<AdminJob["type"], string> = {
-  gpu_seg: "bg-accent/20 text-accent",
-  roast: "bg-blue-500/20 text-blue-400",
-  simnibs: "bg-purple-500/20 text-purple-400",
+const TYPE_STYLE: Record<AdminJob["type"], string> = {
+  gpu_seg: "bg-accent/15 text-accent border border-accent/25",
+  roast: "bg-blue-500/15 text-blue-400 border border-blue-500/25",
+  simnibs: "bg-purple-500/15 text-purple-400 border border-purple-500/25",
 };
 
-function statusBadge(status: string) {
-  const map: Record<string, string> = {
-    queued:      "bg-muted text-muted-foreground",
-    waiting_gpu: "bg-orange-500/20 text-orange-400",
-    running:     "bg-accent/20 text-accent animate-pulse",
-    error:       "bg-destructive/20 text-destructive",
-    cancelled:   "bg-muted text-muted-foreground line-through",
-  };
-  const cls = map[status] ?? "bg-muted text-muted-foreground";
-  return (
-    <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium ${cls}`}>
-      {status}
-    </span>
-  );
-}
+const STATUS_STYLE: Record<string, string> = {
+  queued:      "bg-zinc-500/10 text-zinc-400 border border-zinc-500/20",
+  waiting_gpu: "bg-orange-500/15 text-orange-400 border border-orange-500/25",
+  assigned:    "bg-blue-500/15 text-blue-400 border border-blue-500/25",
+  running:     "bg-accent/15 text-accent border border-accent/25",
+  error:       "bg-red-500/15 text-red-400 border border-red-500/25",
+  cancelled:   "bg-zinc-500/10 text-zinc-500 border border-zinc-500/20 line-through",
+};
+
+const STATUS_DOT: Record<string, string> = {
+  queued:      "bg-zinc-400",
+  waiting_gpu: "bg-orange-400",
+  assigned:    "bg-blue-400",
+  running:     "bg-accent animate-pulse",
+  error:       "bg-red-400",
+  cancelled:   "bg-zinc-500",
+};
 
 export default function JobsPanel({ jobs, onRefresh }: Props) {
   const [cancelling, setCancelling] = useState<Set<string>>(new Set());
@@ -54,66 +55,85 @@ export default function JobsPanel({ jobs, onRefresh }: Props) {
 
   if (jobs.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-20 text-muted-foreground gap-2">
-        <XCircle className="h-8 w-8 opacity-30" />
-        <p className="text-sm">No active jobs</p>
+      <div className="flex flex-col items-center justify-center py-24 gap-3">
+        <div className="p-4 rounded-full bg-surface-elevated">
+          <Inbox className="h-8 w-8 text-foreground-muted" />
+        </div>
+        <p className="text-sm text-foreground-muted">No active jobs</p>
       </div>
     );
   }
 
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b border-border text-xs text-muted-foreground uppercase">
-            <th className="text-left pb-2 pr-4">Type</th>
-            <th className="text-left pb-2 pr-4">Session</th>
-            <th className="text-left pb-2 pr-4">Model</th>
-            <th className="text-left pb-2 pr-4">Status</th>
-            <th className="text-left pb-2 pr-4 w-32">Progress</th>
-            <th className="text-left pb-2 pr-4">GPU</th>
-            <th className="text-left pb-2"></th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-border">
-          {jobs.map((job, i) => (
-            <tr key={i} className="hover:bg-surface/50">
-              <td className="py-2.5 pr-4">
-                <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium ${TYPE_COLOR[job.type]}`}>
-                  {TYPE_LABEL[job.type]}
-                </span>
-              </td>
-              <td className="py-2.5 pr-4 font-mono text-xs">
-                <span title={job.session_id}>{job.session_id.slice(0, 8)}…</span>
-              </td>
-              <td className="py-2.5 pr-4 text-xs text-muted-foreground">{job.model || "—"}</td>
-              <td className="py-2.5 pr-4">{statusBadge(job.status)}</td>
-              <td className="py-2.5 pr-4">
-                <div className="flex items-center gap-2">
-                  <Progress value={job.progress} className="h-1.5 w-24" />
-                  <span className="text-[11px] text-muted-foreground w-8">{Math.round(job.progress)}%</span>
-                </div>
-              </td>
-              <td className="py-2.5 pr-4 text-xs text-muted-foreground">
-                {job.gpu != null ? `GPU ${job.gpu}` : "—"}
-              </td>
-              <td className="py-2.5">
-                {job.status !== "cancelled" && job.status !== "error" && (
-                  <Button
-                    size="sm"
-                    variant="destructive"
-                    className="h-6 px-2 text-[11px]"
-                    disabled={cancelling.has(job.session_id)}
-                    onClick={() => handleCancel(job.session_id)}
-                  >
-                    Cancel
-                  </Button>
-                )}
-              </td>
+    <div className="bg-surface border border-border rounded-xl shadow-medical-lg overflow-hidden animate-fade-in">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border bg-surface-elevated/50">
+              <th className="text-left py-3 px-4 text-xs font-semibold uppercase tracking-wider text-foreground-muted">Type</th>
+              <th className="text-left py-3 px-4 text-xs font-semibold uppercase tracking-wider text-foreground-muted">Session</th>
+              <th className="text-left py-3 px-4 text-xs font-semibold uppercase tracking-wider text-foreground-muted">Model</th>
+              <th className="text-left py-3 px-4 text-xs font-semibold uppercase tracking-wider text-foreground-muted">Status</th>
+              <th className="text-left py-3 px-4 text-xs font-semibold uppercase tracking-wider text-foreground-muted w-40">Progress</th>
+              <th className="text-left py-3 px-4 text-xs font-semibold uppercase tracking-wider text-foreground-muted">GPU</th>
+              <th className="text-left py-3 px-4 text-xs font-semibold uppercase tracking-wider text-foreground-muted"></th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {jobs.map((job, i) => (
+              <tr key={i} className="border-b border-border/50 hover:bg-surface-elevated/40 transition-colors">
+                <td className="py-3 px-4">
+                  <span className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ${TYPE_STYLE[job.type]}`}>
+                    {TYPE_LABEL[job.type]}
+                  </span>
+                </td>
+                <td className="py-3 px-4 font-mono text-xs">
+                  <span title={job.session_id} className="text-foreground-secondary">{job.session_id.slice(0, 10)}</span>
+                </td>
+                <td className="py-3 px-4 text-sm text-foreground-secondary">{job.model || "—"}</td>
+                <td className="py-3 px-4">
+                  <div className="flex items-center gap-2">
+                    <span className={`h-2 w-2 rounded-full shrink-0 ${STATUS_DOT[job.status] ?? "bg-zinc-400"}`} />
+                    <span className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ${STATUS_STYLE[job.status] ?? STATUS_STYLE.queued}`}>
+                      {job.status}
+                    </span>
+                  </div>
+                </td>
+                <td className="py-3 px-4">
+                  <div className="flex items-center gap-3">
+                    <div className="flex-1 h-2 bg-surface-elevated rounded-full overflow-hidden">
+                      <div
+                        className={`h-full rounded-full transition-all duration-500 ${
+                          job.status === "running" ? "bg-accent animate-progress-pulse" : "bg-foreground-muted/30"
+                        }`}
+                        style={{ width: `${job.progress}%` }}
+                      />
+                    </div>
+                    <span className="text-xs text-foreground-muted w-10 text-right font-mono">{Math.round(job.progress)}%</span>
+                  </div>
+                </td>
+                <td className="py-3 px-4 text-sm text-foreground-muted">
+                  {job.gpu != null ? `GPU ${job.gpu}` : "—"}
+                </td>
+                <td className="py-3 px-4">
+                  {job.status !== "cancelled" && job.status !== "error" && (
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      className="h-7 px-3 text-xs gap-1.5"
+                      disabled={cancelling.has(job.session_id)}
+                      onClick={() => handleCancel(job.session_id)}
+                    >
+                      <XCircle className="h-3 w-3" />
+                      Cancel
+                    </Button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/ui/app/dev/page.tsx
+++ b/ui/app/dev/page.tsx
@@ -77,22 +77,34 @@ export default function AdminPage() {
     return <LoginGate onLogin={setToken} />;
   }
 
+  const runningCount = jobsData?.jobs.filter(j => j.status === "running").length ?? 0;
+
   return (
     <div className="min-h-screen bg-background">
-      <div className="max-w-7xl mx-auto px-4 py-6">
+      <div className="max-w-7xl mx-auto px-6 py-8">
         {/* Header */}
-        <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center justify-between mb-8 pb-6 border-b border-border">
           <div>
-            <h1 className="text-xl font-bold">Admin</h1>
-            <p className="text-xs text-muted-foreground mt-0.5">
-              {jobsData ? `${jobsData.jobs.length} active job${jobsData.jobs.length !== 1 ? "s" : ""}` : "Loading…"}
+            <h1 className="text-2xl font-bold text-foreground">Admin Dashboard</h1>
+            <p className="text-sm text-foreground-muted mt-1">
+              {jobsData ? (
+                <>
+                  {runningCount > 0 && (
+                    <span className="inline-flex items-center gap-1.5 mr-3">
+                      <span className="h-2 w-2 rounded-full bg-accent animate-pulse" />
+                      <span className="text-accent font-medium">{runningCount} running</span>
+                    </span>
+                  )}
+                  <span>{jobsData.jobs.length} active job{jobsData.jobs.length !== 1 ? "s" : ""}</span>
+                </>
+              ) : "Loading…"}
             </p>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-3">
             <Button
               size="sm"
               variant="outline"
-              className="h-8 gap-1.5 text-xs"
+              className="h-9 gap-2 text-xs border-border hover:bg-surface-elevated"
               onClick={manualRefresh}
               disabled={refreshing}
             >
@@ -102,7 +114,7 @@ export default function AdminPage() {
             <Button
               size="sm"
               variant="ghost"
-              className="h-8 gap-1.5 text-xs text-muted-foreground"
+              className="h-9 gap-2 text-xs text-foreground-muted hover:text-foreground"
               onClick={handleUnauth}
             >
               <LogOut className="h-3.5 w-3.5" />


### PR DESCRIPTION
Backend: only show jobs with active status (queued/waiting_gpu/assigned/ running) instead of filtering just 'complete'. Fixes ghost 123 jobs count.

Frontend: redesign HealthPanel, JobsPanel, AuditPanel with proper shadows, colored GPU bars, status dots, better badges, visual hierarchy using existing design tokens (shadow-medical-lg, shadow-glow, surface-elevated).