### PR TITLE
fix(redis): prevent ghost entries from progress-only updates

### DIFF
--- a/api/runtime/roast_scheduler.py
+++ b/api/runtime/roast_scheduler.py
@@ -31,7 +31,8 @@ class ROASTScheduler:
             log_error(session_id, "[ROAST] Missing job data in Redis")
             return
 
-        model_name = payload.get("model_name")
+        model_name = payload.get("model_name", "")
+        run_id = payload.get("run_id", "")
         session_log(session_id, f"[ROAST] Dequeued job for model={model_name}")
 
         push_event(session_id, {"event": "roast_start", "progress": 2})
@@ -41,7 +42,7 @@ class ROASTScheduler:
             runner.run()
         except Exception as e:
             log_error(session_id, f"[ROAST] Job failed: {e}")
-            set_roast_status(session_id, "error", model_name or "")
+            set_roast_status(session_id, "error", model_name, run_id)
 
     def scheduler_loop(self):
         log_info("SYSTEM", f"[ROAST] Scheduler started ({self.max_workers} workers)")

--- a/api/runtime/simnibs_scheduler.py
+++ b/api/runtime/simnibs_scheduler.py
@@ -34,12 +34,14 @@ class SimNIBSScheduler:
         session_log(session_id, "[SimNIBS] Dequeued job")
         push_event(session_id, {"event": "simnibs_start", "progress": 2})
 
+        model_name = payload.get("model_name", "")
+        run_id = payload.get("run_id", "")
         try:
             runner = SimNIBSRunner(session_id, payload)
             runner.run()
         except Exception as e:
             log_error(session_id, f"[SimNIBS] Job failed: {e}")
-            set_simnibs_status(session_id, "error")
+            set_simnibs_status(session_id, "error", model_name, run_id)
 
     def scheduler_loop(self):
         log_info("SYSTEM", f"[SimNIBS] Scheduler started ({self.max_workers} workers)")

--- a/api/services/redis_client.py
+++ b/api/services/redis_client.py
@@ -44,28 +44,38 @@ def _upsert_job(job_type: str, session_id: str, model: str, run_id: str = "",
                 gpu: str | None = None) -> None:
     """Insert or update a job in the active_jobs registry.
 
-    Automatically removes the entry when `status` is terminal.
+    - Terminal status (complete/error/cancelled): removes the entry.
+    - Progress-only update (status=None) with no existing entry: skipped
+      (the job has already been removed, no need to recreate it).
     """
     field = _active_field(job_type, session_id, model, run_id)
     if status in _TERMINAL:
         redis_client.hdel(ACTIVE_JOBS_KEY, field)
         return
     raw = redis_client.hget(ACTIVE_JOBS_KEY, field)
-    data: dict = json.loads(raw) if raw else {
-        "type": job_type,
-        "session_id": session_id,
-        "model": model,
-        "run_id": run_id or None,
-        "status": "queued",
-        "progress": 0.0,
-        "gpu": None,
-    }
-    if status is not None:
-        data["status"] = status
-    if progress is not None:
-        data["progress"] = float(progress)
-    if gpu is not None:
-        data["gpu"] = str(gpu)
+    if raw is None:
+        if status is None:
+            # Progress-only update for a job not in the registry — already
+            # completed/removed, nothing to do.
+            return
+        # First time we see this job — create the entry.
+        data: dict = {
+            "type": job_type,
+            "session_id": session_id,
+            "model": model,
+            "run_id": run_id or None,
+            "status": status,
+            "progress": float(progress) if progress is not None else 0.0,
+            "gpu": str(gpu) if gpu is not None else None,
+        }
+    else:
+        data = json.loads(raw)
+        if status is not None:
+            data["status"] = status
+        if progress is not None:
+            data["progress"] = float(progress)
+        if gpu is not None:
+            data["gpu"] = str(gpu)
     redis_client.hset(ACTIVE_JOBS_KEY, field, json.dumps(data))
 
 


### PR DESCRIPTION
_upsert_job now skips creating a new active_jobs entry when called with status=None (progress-only update) and the job is not in the registry. This prevents completed jobs from reappearing as ghost entries.

Also pass model_name and run_id in scheduler-level error handlers so the correct active_jobs field is removed on failure.