### PR TITLE
feat: workspace auth, tissue volume stats, job completion emails

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -26,8 +26,17 @@ from services.redis_client import (
     enqueue_roast_job, get_roast_status, get_roast_progress, set_roast_status,
     enqueue_simnibs_job, get_simnibs_status, get_simnibs_progress, set_simnibs_status,
 )
-from config import GPU_COUNT, SESSION_DIR, DB_PATH, NOTIFY_TOKEN_TTL, FRONTEND_URL, ALLOWED_ORIGINS, ADMIN_PASSWORD
-from services.auth import require_jwt, create_jwt
+from config import (
+    GPU_COUNT, SESSION_DIR, DB_PATH, NOTIFY_TOKEN_TTL, FRONTEND_URL, ALLOWED_ORIGINS,
+    ADMIN_PASSWORD, MAGIC_TOKEN_TTL_MINUTES, MAGIC_LINK_RATE_LIMIT_MAX, MAGIC_LINK_RATE_LIMIT_WINDOW,
+)
+from services.auth import require_jwt, require_admin_jwt, optional_user_jwt, create_jwt
+from services.workspace_db import (
+    init_workspace_db, get_or_create_user, check_rate_limit, record_magic_link_request,
+    create_magic_token, consume_magic_token, get_user_by_id, get_user_retention_days,
+    delete_user, prune_old_requests, prune_expired_tokens,
+)
+from services.volume_stats import get_or_compute_stats
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -79,6 +88,7 @@ def _cleanup_stale_jobs():
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # STARTUP
+    init_workspace_db()
     _cleanup_stale_jobs()
     import threading
     t = threading.Thread(target=scheduler.scheduler_loop, daemon=True)
@@ -93,12 +103,15 @@ async def lifespan(app: FastAPI):
     t4.start()
     print("SimNIBS Scheduler started under lifespan()")
 
-    # Session cleanup loop (runs every hour, deletes sessions >24h old)
+    # Session cleanup loop (runs every hour, deletes sessions past retention)
     def cleanup_loop():
         while True:
-            deleted = cleanup_old_sessions(max_age_hours=24)
+            deleted = cleanup_old_sessions(default_max_age_hours=24)
             if deleted:
                 print(f"Session cleanup: removed {deleted} old session(s)")
+            # Prune workspace DB stale rows
+            prune_old_requests()
+            prune_expired_tokens()
             time.sleep(3600)
 
     t3 = threading.Thread(target=cleanup_loop, daemon=True)
@@ -175,6 +188,8 @@ async def predict(
     models: str = Body(...),
     space: str = Body(...),
     convert_to_fs: str = Body("false"),
+    notify_email: str = Body(""),
+    workspace_payload: dict | None = Depends(optional_user_jwt),
 ):
     # Validate input
     if not (file.filename.endswith(".nii") or file.filename.endswith(".nii.gz")):
@@ -234,6 +249,20 @@ async def predict(
             "plan": plan,
         }
     )
+
+    # Link session to workspace user if authenticated
+    if workspace_payload and workspace_payload.get("role") == "user":
+        user_id = workspace_payload["user_id"]
+        retention = get_user_retention_days(user_id)
+        redis_client.set(f"session_owner:{session_id}", str(user_id), ex=retention * 86400)
+        redis_client.sadd(f"user_sessions:{user_id}", session_id)
+
+    # Register notification email (workspace email takes priority over explicit field)
+    _notify = notify_email.strip() if notify_email else ""
+    if not _notify and workspace_payload and workspace_payload.get("role") == "user":
+        _notify = workspace_payload.get("email", "")
+    if _notify and "@" in _notify:
+        redis_client.setex(f"notify_email:{session_id}", NOTIFY_TOKEN_TTL, _notify)
 
     # Return queue position
     pos = get_queue_position(session_id)
@@ -564,9 +593,19 @@ async def stream_simnibs(session_id: str):
 # DELETE /session/{session_id}  — Immediately delete session data
 # ============================================================
 @app.delete("/session/{session_id}")
-async def delete_session(session_id: str, _: str = Depends(require_jwt)):
-    """Delete all data for a session immediately (directory + Redis keys). Requires JWT."""
+async def delete_session(session_id: str, token_payload: dict = Depends(require_jwt)):
+    """Delete all data for a session. Admin JWT always allowed; user JWT only if they own the session."""
     _validate_session_id(session_id)
+
+    # Ownership check for workspace users
+    if token_payload.get("role") == "user":
+        owner = redis_client.get(f"session_owner:{session_id}")
+        if isinstance(owner, bytes):
+            owner = owner.decode()
+        if owner != str(token_payload.get("user_id", "")):
+            raise HTTPException(status_code=403, detail="You do not own this session")
+        # Remove from user's session set
+        redis_client.srem(f"user_sessions:{token_payload['user_id']}", session_id)
 
     session_dir = SESSION_DIR / session_id
     deleted_dir = False
@@ -651,7 +690,7 @@ async def session_restore(token: str):
 # GET /logs  — Dev endpoint: list all sessions with logs (requires JWT)
 # ============================================================
 @app.get("/logs")
-def list_sessions(_: str = Depends(require_jwt)):
+def list_sessions(_: dict = Depends(require_admin_jwt)):
     sessions_path = Path(SESSION_DIR)
     if not sessions_path.exists():
         return {"sessions": []}
@@ -672,7 +711,7 @@ def list_sessions(_: str = Depends(require_jwt)):
 # GET /logs/{session_id}  — Dev endpoint (requires JWT)
 # ============================================================
 @app.get("/logs/{session_id}")
-def get_session_logs(session_id: str, _: str = Depends(require_jwt)):
+def get_session_logs(session_id: str, _: dict = Depends(require_admin_jwt)):
     lp = Path(SESSION_DIR) / session_id / "logs.jsonl"
     if not lp.exists():
         raise HTTPException(404, "No logs for session")
@@ -745,7 +784,7 @@ async def health():
 # GET /admin/logs/{session_id}
 # ============================================================
 @app.get("/admin/logs/{session_id}")
-def get_logs(session_id: str, _: str = Depends(require_jwt)):
+def get_logs(session_id: str, _: dict = Depends(require_admin_jwt)):
     lp = Path(SESSION_DIR) / session_id / "logs.jsonl"
     if not lp.exists():
         raise HTTPException(404, "No logs for session")
@@ -768,7 +807,7 @@ async def admin_login(body: dict = Body(...)):
 # GET /admin/jobs  — aggregate live jobs across all schedulers
 # ============================================================
 @app.get("/admin/jobs")
-def get_admin_jobs(_: str = Depends(require_jwt)):
+def get_admin_jobs(_: dict = Depends(require_admin_jwt)):
     # Read the active_jobs registry — O(n active jobs), no scanning needed.
     raw_jobs = redis_client.hgetall("active_jobs") or {}
     jobs = []
@@ -792,7 +831,7 @@ def get_admin_jobs(_: str = Depends(require_jwt)):
 # ============================================================
 @app.get("/admin/audit")
 def get_audit(
-    _: str = Depends(require_jwt),
+    _: dict = Depends(require_admin_jwt),
     offset: int = 0,
     limit: int = 100,
 ):
@@ -819,6 +858,149 @@ async def cancel_job(session_id: str):
     cancel_session(session_id)
     push_event(session_id, {"event": "job_cancelled"})
     return {"status": "cancellation_requested"}
+
+
+# ============================================================
+# GET /results/{session_id}/{model_name}/stats  — tissue volume stats
+# ============================================================
+@app.get("/results/{session_id}/{model_name}/stats")
+async def get_model_stats(session_id: str, model_name: str):
+    """Return per-label tissue volume statistics (mm³) for a segmentation output."""
+    _validate_session_id(session_id)
+    _validate_model_name(model_name)
+    out_path = model_output_path(session_id, model_name)
+    if not out_path.exists():
+        raise HTTPException(status_code=404, detail="Model output not found")
+
+    cache_path = out_path.parent / "stats.json"
+    result = get_or_compute_stats(out_path, cache_path)
+    return {"session_id": session_id, "model_name": model_name, **result}
+
+
+# ============================================================
+# WORKSPACE endpoints
+# ============================================================
+import re as _email_re
+
+_EMAIL_RE = _email_re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def _validate_email(email: str) -> str:
+    if not email or not _EMAIL_RE.match(email):
+        raise HTTPException(status_code=400, detail="Valid email address required")
+    return email.strip().lower()
+
+
+@app.post("/workspace/request-magic-link")
+async def workspace_request_magic_link(body: dict = Body(...)):
+    """Send a magic sign-in link. Always returns {"status": "sent"} (no email enumeration)."""
+    email = _validate_email(body.get("email", "").strip())
+
+    if not check_rate_limit(email, MAGIC_LINK_RATE_LIMIT_MAX, MAGIC_LINK_RATE_LIMIT_WINDOW):
+        raise HTTPException(
+            status_code=429,
+            detail=f"Too many requests. Try again in {MAGIC_LINK_RATE_LIMIT_WINDOW} minutes.",
+        )
+
+    record_magic_link_request(email)
+    user_id, _ = get_or_create_user(email)
+    token = create_magic_token(user_id, ttl_minutes=MAGIC_TOKEN_TTL_MINUTES)
+
+    magic_url = f"{FRONTEND_URL}/workspace/verify?token={token}"
+
+    from services.email import send_magic_link_email
+    threading.Thread(target=send_magic_link_email, args=(email, magic_url), daemon=True).start()
+
+    from services.audit import audit_event
+    audit_event("SYSTEM", "", "magic_link_request", f"email={email}")
+
+    return {"status": "sent"}
+
+
+@app.get("/workspace/verify/{token}")
+async def workspace_verify(token: str):
+    """Consume a magic token and return a workspace JWT."""
+    user_id = consume_magic_token(token)
+    if user_id is None:
+        raise HTTPException(status_code=401, detail="Invalid or expired sign-in link")
+
+    user = get_user_by_id(user_id)
+    if not user:
+        raise HTTPException(status_code=500, detail="User not found after token validation")
+
+    jwt_token = create_jwt(
+        {"role": "user", "user_id": user["id"], "email": user["email"]},
+        expires_minutes=480,
+    )
+
+    from services.audit import audit_event
+    audit_event("SYSTEM", "", "workspace_login", f"user_id={user_id} email={user['email']}")
+
+    return {
+        "token": jwt_token,
+        "email": user["email"],
+        "retention_days": user["retention_days"],
+    }
+
+
+@app.get("/workspace/me")
+async def workspace_me(payload: dict = Depends(require_jwt)):
+    if payload.get("role") != "user":
+        raise HTTPException(status_code=403, detail="Workspace user account required")
+    user = get_user_by_id(payload["user_id"])
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@app.get("/workspace/sessions")
+async def workspace_sessions(payload: dict = Depends(require_jwt)):
+    if payload.get("role") != "user":
+        raise HTTPException(status_code=403, detail="Workspace user account required")
+    user_id = payload["user_id"]
+    raw = redis_client.smembers(f"user_sessions:{user_id}") or set()
+    sessions = []
+    for sid in raw:
+        if isinstance(sid, bytes):
+            sid = sid.decode()
+        if (SESSION_DIR / sid).exists():
+            sessions.append(sid)
+        else:
+            # Clean up stale entry
+            redis_client.srem(f"user_sessions:{user_id}", sid)
+    return {"sessions": sessions}
+
+
+@app.delete("/workspace/account")
+async def workspace_delete_account(payload: dict = Depends(require_jwt)):
+    if payload.get("role") != "user":
+        raise HTTPException(status_code=403, detail="Workspace user account required")
+    user_id = payload["user_id"]
+
+    # Collect and delete all owned sessions
+    raw = redis_client.smembers(f"user_sessions:{user_id}") or set()
+    sessions_removed = 0
+    for sid in raw:
+        if isinstance(sid, bytes):
+            sid = sid.decode()
+        session_dir = SESSION_DIR / sid
+        if session_dir.exists():
+            shutil.rmtree(str(session_dir), ignore_errors=True)
+            sessions_removed += 1
+        # Clean up Redis keys for this session
+        try:
+            for key in redis_client.scan_iter(f"*{sid}*"):
+                redis_client.delete(key)
+        except Exception:
+            pass
+
+    redis_client.delete(f"user_sessions:{user_id}")
+    delete_user(user_id)
+
+    from services.audit import audit_event
+    audit_event("SYSTEM", "", "workspace_deleted", f"user_id={user_id} sessions_removed={sessions_removed}")
+
+    return {"deleted": True, "sessions_removed": sessions_removed}
 
 
 # ============================================================

--- a/api/config.py
+++ b/api/config.py
@@ -98,6 +98,17 @@ FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:3000")
 NOTIFY_TOKEN_TTL = int(os.getenv("NOTIFY_TOKEN_TTL", str(6 * 3600)))
 
 # -------------------------------------------------------
+# WORKSPACE CONFIG
+# -------------------------------------------------------
+# Default session retention for workspace users (days)
+WORKSPACE_DEFAULT_RETENTION_DAYS = int(os.getenv("WORKSPACE_DEFAULT_RETENTION_DAYS", "7"))
+# Magic link token TTL (minutes)
+MAGIC_TOKEN_TTL_MINUTES = int(os.getenv("MAGIC_TOKEN_TTL_MINUTES", "15"))
+# Rate limiting: max magic link requests per email per window
+MAGIC_LINK_RATE_LIMIT_MAX = int(os.getenv("MAGIC_LINK_RATE_LIMIT_MAX", "3"))
+MAGIC_LINK_RATE_LIMIT_WINDOW = int(os.getenv("MAGIC_LINK_RATE_LIMIT_WINDOW", "10"))  # minutes
+
+# -------------------------------------------------------
 # FREESURFER
 # -------------------------------------------------------
 # Path to FreeSurfer tools inside Docker

--- a/api/runtime/roast_runner.py
+++ b/api/runtime/roast_runner.py
@@ -687,6 +687,8 @@ class ROASTRunner:
             set_roast_status(self.session_id, "complete", self.model_name, self.run_id)
             self._emit("roast_complete", 100)
             session_log(self.session_id, "[ROAST] Completed successfully")
+            from services.notify import maybe_send_completion_notification
+            maybe_send_completion_notification(self.session_id, "ROAST simulation", [self.model_name])
 
         except Exception as e:
             log_error(self.session_id, f"[ROAST] Failed: {e}")

--- a/api/runtime/scheduler.py
+++ b/api/runtime/scheduler.py
@@ -179,6 +179,8 @@ class GPUScheduler:
             push_event(job_id, {"event": "job_complete"})
             log_event(job_id, {"event": "job_complete"})
             session_log(job_id, "Job complete.")
+            from services.notify import maybe_send_completion_notification
+            maybe_send_completion_notification(job_id, "segmentation", payload.get("models", []))
 
     def scheduler_loop(self):
         log_info("SYSTEM", f"Scheduler started with {self.num_gpus} GPUs.")

--- a/api/runtime/session.py
+++ b/api/runtime/session.py
@@ -147,14 +147,17 @@ def session_exists(session_id: str) -> bool:
 # -----------------------------------------------------------
 # CLEANUP
 # -----------------------------------------------------------
-def cleanup_old_sessions(max_age_hours: int = 24) -> int:
+def cleanup_old_sessions(default_max_age_hours: int = 24) -> int:
     """
-    Delete session directories older than max_age_hours.
+    Delete session directories past their retention period.
+    Workspace sessions use the user's configured retention_days.
+    Anonymous sessions use default_max_age_hours.
     Returns number of sessions deleted.
     """
-    cutoff = time.time() - (max_age_hours * 3600)
-    deleted = 0
+    from services.redis_client import redis_client
+    from services.workspace_db import get_user_retention_days
 
+    deleted = 0
     sessions_root = Path(SESSION_DIR)
     if not sessions_root.exists():
         return 0
@@ -162,10 +165,23 @@ def cleanup_old_sessions(max_age_hours: int = 24) -> int:
     for session_dir in sessions_root.iterdir():
         if not session_dir.is_dir():
             continue
+
+        owner = redis_client.get(f"session_owner:{session_dir.name}")
+        if owner:
+            if isinstance(owner, bytes):
+                owner = owner.decode()
+            try:
+                retention_days = get_user_retention_days(int(owner))
+            except Exception:
+                retention_days = 7
+            cutoff = time.time() - retention_days * 86400
+        else:
+            cutoff = time.time() - default_max_age_hours * 3600
+
         if session_dir.stat().st_mtime < cutoff:
             try:
                 shutil.rmtree(session_dir)
-                log_info("SYSTEM", f"Cleaned up old session: {session_dir.name} (>{max_age_days}d old)")
+                log_info("SYSTEM", f"Cleaned up old session: {session_dir.name}")
                 deleted += 1
             except Exception as e:
                 log_info("SYSTEM", f"Failed to delete session {session_dir.name}: {e}")

--- a/api/runtime/simnibs_runner.py
+++ b/api/runtime/simnibs_runner.py
@@ -830,6 +830,8 @@ class SimNIBSRunner:
             set_simnibs_status(self.session_id, "complete", self.model_name, self.run_id)
             self._emit("simnibs_complete", 100)
             session_log(self.session_id, "[SimNIBS] Completed successfully")
+            from services.notify import maybe_send_completion_notification
+            maybe_send_completion_notification(self.session_id, "SimNIBS simulation", [self.model_name])
 
         except Exception as exc:
             log_error(self.session_id, f"[SimNIBS] Failed: {exc}")

--- a/api/services/auth.py
+++ b/api/services/auth.py
@@ -21,11 +21,49 @@ def validate_jwt(token: str) -> bool:
         return False
 
 
-def require_jwt(authorization: str = Header(...)) -> str:
-    """FastAPI dependency: enforces a valid Bearer JWT on protected endpoints."""
+def decode_jwt(token: str) -> dict | None:
+    """Decode and validate a JWT. Returns full payload or None on failure."""
+    try:
+        return jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+    except Exception:
+        return None
+
+
+def _extract_bearer(authorization: str) -> str | None:
     if not authorization.startswith("Bearer "):
+        return None
+    return authorization.split(" ", 1)[1]
+
+
+def require_jwt(authorization: str = Header(...)) -> dict:
+    """FastAPI dependency: accepts admin OR workspace user JWT. Returns decoded payload."""
+    token = _extract_bearer(authorization)
+    if not token:
         raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
-    token = authorization.split(" ", 1)[1]
-    if not validate_jwt(token):
+    payload = decode_jwt(token)
+    if not payload:
         raise HTTPException(status_code=401, detail="Invalid or expired token")
-    return token
+    return payload
+
+
+def require_admin_jwt(authorization: str = Header(...)) -> dict:
+    """FastAPI dependency: accepts only admin JWTs (role=admin)."""
+    token = _extract_bearer(authorization)
+    if not token:
+        raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
+    payload = decode_jwt(token)
+    if not payload:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+    if payload.get("role") != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+    return payload
+
+
+def optional_user_jwt(authorization: str = Header(default="")) -> dict | None:
+    """FastAPI dependency: returns decoded payload if a valid JWT is present, else None."""
+    if not authorization:
+        return None
+    token = _extract_bearer(authorization)
+    if not token:
+        return None
+    return decode_jwt(token)

--- a/api/services/email.py
+++ b/api/services/email.py
@@ -1,5 +1,5 @@
 """
-Email service for CROWN restore-link notifications.
+Email service for CROWN notifications (restore links, magic links, job completion).
 Uses Python's built-in smtplib with STARTTLS. All errors are logged and
 swallowed so that a missing SMTP config never breaks the API.
 """
@@ -82,3 +82,119 @@ If you didn't request this link, you can safely ignore this email.
     except Exception as exc:
         log.error("[Email] Failed to send to %s: %s", to, exc)
         return False
+
+
+def _send(msg: MIMEMultipart, to: str, label: str) -> bool:
+    """Internal SMTP send helper."""
+    if not SMTP_HOST:
+        log.warning("[Email] SMTP_HOST not configured — skipping %s to %s", label, to)
+        return False
+    try:
+        ctx = ssl.create_default_context()
+        with smtplib.SMTP(SMTP_HOST, SMTP_PORT, timeout=10) as server:
+            server.ehlo()
+            server.starttls(context=ctx)
+            if SMTP_USER:
+                server.login(SMTP_USER, SMTP_PASS)
+            server.sendmail(SMTP_FROM, to, msg.as_string())
+        log.info("[Email] %s sent to %s", label, to)
+        return True
+    except Exception as exc:
+        log.error("[Email] Failed to send %s to %s: %s", label, to, exc)
+        return False
+
+
+def send_magic_link_email(to: str, magic_url: str) -> bool:
+    """Send a workspace magic sign-in link. Valid for 15 minutes."""
+    body_text = f"""Hello,
+
+Click the link below to sign in to your CROWN workspace. This link is valid for 15 minutes and can only be used once.
+
+{magic_url}
+
+If you didn't request this, you can safely ignore this email.
+
+— CROWN Automated Notification
+"""
+
+    body_html = f"""<!DOCTYPE html>
+<html>
+<body style="font-family:sans-serif;color:#333;max-width:520px;margin:auto;padding:24px">
+  <div style="margin-bottom:24px">
+    <span style="font-family:monospace;font-weight:700;font-size:20px;letter-spacing:0.2em">CROWN</span>
+    <span style="font-size:11px;color:#888;margin-left:8px">Whole-Head Segmentation</span>
+  </div>
+  <h2 style="font-size:18px;margin-bottom:8px">Sign in to your workspace</h2>
+  <p style="color:#555;margin-bottom:20px">
+    Click the button below to sign in. This link is valid for <strong>15 minutes</strong>
+    and can only be used once.
+  </p>
+  <a href="{magic_url}"
+     style="display:inline-block;background:#6366f1;color:#fff;text-decoration:none;
+            padding:12px 24px;border-radius:8px;font-weight:600;font-size:14px">
+    Sign in to CROWN →
+  </a>
+  <p style="margin-top:24px;font-size:12px;color:#999">
+    If you didn't request this sign-in link, you can safely ignore this email.
+  </p>
+</body>
+</html>"""
+
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = "CROWN: Your sign-in link"
+    msg["From"] = SMTP_FROM
+    msg["To"] = to
+    msg.attach(MIMEText(body_text, "plain"))
+    msg.attach(MIMEText(body_html, "html"))
+    return _send(msg, to, "magic link")
+
+
+def send_completion_email(
+    to: str,
+    session_id: str,
+    job_type: str,
+    completed_models: list[str],
+    results_url: str,
+) -> bool:
+    """Send a job completion notification."""
+    models_text = ", ".join(completed_models) if completed_models else "your job"
+    models_html = "".join(f"<li>{m}</li>" for m in completed_models) if completed_models else "<li>Job complete</li>"
+
+    body_text = f"""Hello,
+
+Your {job_type} job has finished processing.
+
+Models completed: {models_text}
+Session ID: {session_id}
+
+View your results: {results_url}
+
+— CROWN Automated Notification
+"""
+
+    body_html = f"""<!DOCTYPE html>
+<html>
+<body style="font-family:sans-serif;color:#333;max-width:520px;margin:auto;padding:24px">
+  <div style="margin-bottom:24px">
+    <span style="font-family:monospace;font-weight:700;font-size:20px;letter-spacing:0.2em">CROWN</span>
+    <span style="font-size:11px;color:#888;margin-left:8px">Whole-Head Segmentation</span>
+  </div>
+  <h2 style="font-size:18px;margin-bottom:8px">Your {job_type} is ready</h2>
+  <p style="color:#555;margin-bottom:12px">The following models completed successfully:</p>
+  <ul style="color:#333;margin-bottom:20px">{models_html}</ul>
+  <p style="font-size:12px;color:#888;margin-bottom:20px">Session: <code>{session_id}</code></p>
+  <a href="{results_url}"
+     style="display:inline-block;background:#6366f1;color:#fff;text-decoration:none;
+            padding:12px 24px;border-radius:8px;font-weight:600;font-size:14px">
+    View results →
+  </a>
+</body>
+</html>"""
+
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = f"CROWN: {job_type} complete"
+    msg["From"] = SMTP_FROM
+    msg["To"] = to
+    msg.attach(MIMEText(body_text, "plain"))
+    msg.attach(MIMEText(body_html, "html"))
+    return _send(msg, to, f"{job_type} completion")

--- a/api/services/notify.py
+++ b/api/services/notify.py
@@ -1,0 +1,43 @@
+"""
+Job completion notification helper.
+Checks Redis for a stored notify_email for a session and fires a background
+email if found. Uses GETDEL to atomically retrieve-and-delete the key,
+preventing duplicate sends if multiple completion events fire.
+"""
+import logging
+import threading
+
+from config import FRONTEND_URL
+from services.email import send_completion_email
+
+log = logging.getLogger(__name__)
+
+
+def maybe_send_completion_notification(
+    session_id: str,
+    job_type: str,
+    completed_models: list[str],
+) -> None:
+    """
+    Non-blocking. Check if an email was registered for this session and send
+    a completion notification. Deletes the Redis key atomically to prevent
+    duplicate sends.
+    """
+    # Import here to avoid circular imports at module load time
+    from services.redis_client import redis_client
+
+    email = redis_client.getdel(f"notify_email:{session_id}")
+    if not email:
+        return
+
+    if isinstance(email, bytes):
+        email = email.decode()
+
+    results_url = f"{FRONTEND_URL}/?session={session_id}"
+
+    threading.Thread(
+        target=send_completion_email,
+        args=(email, session_id, job_type, completed_models, results_url),
+        daemon=True,
+    ).start()
+    log.info("[Notify] Queued completion email for session %s → %s", session_id, email)

--- a/api/services/volume_stats.py
+++ b/api/services/volume_stats.py
@@ -1,0 +1,73 @@
+"""
+Tissue volume statistics from NIfTI segmentation outputs.
+Counts voxels per label class and converts to mm³ using the image affine.
+Results are cached as stats.json in the model output directory.
+"""
+import json
+import logging
+from pathlib import Path
+
+import nibabel as nib
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+LABEL_NAMES: dict[int, str] = {
+    0:  "Background",
+    1:  "White Matter",
+    2:  "Grey Matter",
+    3:  "Eyes",
+    4:  "CSF",
+    5:  "Air (internal)",
+    6:  "Blood",
+    7:  "Spongy Bone",
+    8:  "Compact Bone",
+    9:  "Skin",
+    10: "Fat",
+    11: "Muscle",
+}
+
+
+def compute_label_volumes(nifti_path: Path) -> dict:
+    """
+    Load a NIfTI label map and compute per-label voxel counts and mm³ volumes.
+    Returns a dict ready to serialise as JSON.
+    """
+    img = nib.load(str(nifti_path))
+    data = np.asarray(img.dataobj, dtype=np.int16)
+    zooms = img.header.get_zooms()[:3]
+    voxel_volume_mm3 = float(zooms[0] * zooms[1] * zooms[2])
+
+    labels: dict[str, dict] = {}
+    for label_id, label_name in LABEL_NAMES.items():
+        count = int(np.sum(data == label_id))
+        labels[str(label_id)] = {
+            "name": label_name,
+            "voxel_count": count,
+            "volume_mm3": round(count * voxel_volume_mm3, 2),
+        }
+
+    return {
+        "voxel_volume_mm3": round(voxel_volume_mm3, 4),
+        "labels": labels,
+    }
+
+
+def get_or_compute_stats(nifti_path: Path, cache_path: Path) -> dict:
+    """
+    Return cached stats if available, otherwise compute and cache them.
+    """
+    if cache_path.exists():
+        try:
+            return json.loads(cache_path.read_text())
+        except Exception:
+            pass  # corrupted cache — recompute
+
+    result = compute_label_volumes(nifti_path)
+
+    try:
+        cache_path.write_text(json.dumps(result))
+    except Exception as exc:
+        log.warning("[VolumeStats] Could not write cache to %s: %s", cache_path, exc)
+
+    return result

--- a/api/services/workspace_db.py
+++ b/api/services/workspace_db.py
@@ -1,0 +1,212 @@
+"""
+Workspace database — optional user accounts with magic-link authentication.
+Separate SQLite DB (workspace.db) from the audit log.
+"""
+import logging
+import secrets
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from config import LOG_DIR
+
+log = logging.getLogger(__name__)
+
+WORKSPACE_DB_PATH = LOG_DIR / "workspace.db"
+
+# ---------------------------------------------------------------------------
+# Connection
+# ---------------------------------------------------------------------------
+
+def _conn() -> sqlite3.Connection:
+    c = sqlite3.connect(str(WORKSPACE_DB_PATH))
+    c.execute("PRAGMA journal_mode=WAL")
+    c.execute("PRAGMA foreign_keys=ON")
+    c.row_factory = sqlite3.Row
+    return c
+
+
+def init_workspace_db() -> None:
+    conn = _conn()
+    cur = conn.cursor()
+    cur.executescript("""
+        CREATE TABLE IF NOT EXISTS users (
+            id             INTEGER PRIMARY KEY AUTOINCREMENT,
+            email          TEXT UNIQUE NOT NULL COLLATE NOCASE,
+            created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+            last_login     TEXT,
+            retention_days INTEGER NOT NULL DEFAULT 7
+        );
+
+        CREATE TABLE IF NOT EXISTS magic_tokens (
+            token       TEXT PRIMARY KEY,
+            user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+            expires_at  TEXT NOT NULL,
+            used        INTEGER NOT NULL DEFAULT 0
+        );
+
+        CREATE TABLE IF NOT EXISTS magic_link_requests (
+            id           INTEGER PRIMARY KEY AUTOINCREMENT,
+            email        TEXT NOT NULL COLLATE NOCASE,
+            requested_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_magic_tokens_expires
+            ON magic_tokens(expires_at);
+        CREATE INDEX IF NOT EXISTS idx_mlr_email
+            ON magic_link_requests(email, requested_at);
+    """)
+    conn.commit()
+    conn.close()
+    log.info("[Workspace] DB initialised at %s", WORKSPACE_DB_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Users
+# ---------------------------------------------------------------------------
+
+def get_or_create_user(email: str) -> tuple[int, bool]:
+    """Return (user_id, is_new)."""
+    conn = _conn()
+    cur = conn.cursor()
+    cur.execute("INSERT OR IGNORE INTO users (email) VALUES (?)", (email,))
+    is_new = cur.rowcount == 1
+    conn.commit()
+    cur.execute("SELECT id FROM users WHERE email = ?", (email,))
+    row = cur.fetchone()
+    conn.close()
+    return row["id"], is_new
+
+
+def get_user_by_id(user_id: int) -> dict | None:
+    conn = _conn()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT id, email, created_at, last_login, retention_days FROM users WHERE id = ?",
+        (user_id,),
+    )
+    row = cur.fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+def get_user_retention_days(user_id: int) -> int:
+    conn = _conn()
+    cur = conn.cursor()
+    cur.execute("SELECT retention_days FROM users WHERE id = ?", (user_id,))
+    row = cur.fetchone()
+    conn.close()
+    return row["retention_days"] if row else 7
+
+
+def update_retention_days(user_id: int, days: int) -> None:
+    conn = _conn()
+    conn.execute("UPDATE users SET retention_days = ? WHERE id = ?", (days, user_id))
+    conn.commit()
+    conn.close()
+
+
+def delete_user(user_id: int) -> None:
+    """Delete user row (cascades magic_tokens). Caller handles session cleanup."""
+    conn = _conn()
+    conn.execute("DELETE FROM users WHERE id = ?", (user_id,))
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting
+# ---------------------------------------------------------------------------
+
+def check_rate_limit(email: str, max_requests: int = 3, window_minutes: int = 10) -> bool:
+    """Return True if under limit (request is allowed)."""
+    conn = _conn()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT COUNT(*) AS cnt FROM magic_link_requests "
+        "WHERE email = ? AND requested_at > datetime('now', ?)",
+        (email, f"-{window_minutes} minutes"),
+    )
+    count = cur.fetchone()["cnt"]
+    conn.close()
+    return count < max_requests
+
+
+def record_magic_link_request(email: str) -> None:
+    conn = _conn()
+    conn.execute("INSERT INTO magic_link_requests (email) VALUES (?)", (email,))
+    conn.commit()
+    conn.close()
+
+
+def prune_old_requests(older_than_minutes: int = 60) -> int:
+    """Delete stale rate-limit rows. Call hourly."""
+    conn = _conn()
+    cur = conn.cursor()
+    cur.execute(
+        "DELETE FROM magic_link_requests WHERE requested_at < datetime('now', ?)",
+        (f"-{older_than_minutes} minutes",),
+    )
+    deleted = cur.rowcount
+    conn.commit()
+    conn.close()
+    return deleted
+
+
+# ---------------------------------------------------------------------------
+# Magic tokens
+# ---------------------------------------------------------------------------
+
+def create_magic_token(user_id: int, ttl_minutes: int = 15) -> str:
+    """Create a one-time-use token with 256-bit entropy."""
+    token = secrets.token_urlsafe(32)
+    expires_at = (
+        datetime.now(timezone.utc) + timedelta(minutes=ttl_minutes)
+    ).strftime("%Y-%m-%d %H:%M:%S")
+    conn = _conn()
+    conn.execute(
+        "INSERT INTO magic_tokens (token, user_id, expires_at) VALUES (?, ?, ?)",
+        (token, user_id, expires_at),
+    )
+    conn.commit()
+    conn.close()
+    return token
+
+
+def consume_magic_token(token: str) -> int | None:
+    """
+    Validate and consume a magic token.
+    Returns user_id on success, None if invalid/expired/already used.
+    """
+    conn = _conn()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT user_id FROM magic_tokens "
+        "WHERE token = ? AND used = 0 AND expires_at > datetime('now')",
+        (token,),
+    )
+    row = cur.fetchone()
+    if not row:
+        conn.close()
+        return None
+
+    user_id = row["user_id"]
+    cur.execute("UPDATE magic_tokens SET used = 1 WHERE token = ?", (token,))
+    cur.execute("UPDATE users SET last_login = datetime('now') WHERE id = ?", (user_id,))
+    conn.commit()
+    conn.close()
+    return user_id
+
+
+def prune_expired_tokens() -> int:
+    """Delete used/expired magic tokens. Call hourly."""
+    conn = _conn()
+    cur = conn.cursor()
+    cur.execute(
+        "DELETE FROM magic_tokens WHERE used = 1 OR expires_at < datetime('now', '-1 hour')"
+    )
+    deleted = cur.rowcount
+    conn.commit()
+    conn.close()
+    return deleted

--- a/ui/app/ClientLayout.tsx
+++ b/ui/app/ClientLayout.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { JobProvider } from "../context/JobContext";
+import { WorkspaceProvider } from "../context/WorkspaceContext";
 import Header from "./components/layout/Header";
 
 export default function ClientLayout({ children }: { children: React.ReactNode }) {
   return (
+    <WorkspaceProvider>
     <JobProvider>
       <div className="flex min-h-screen flex-col">
         <Header />
@@ -27,5 +29,6 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
         </footer>
       </div>
     </JobProvider>
+    </WorkspaceProvider>
   );
 }

--- a/ui/app/components/layout/Header.tsx
+++ b/ui/app/components/layout/Header.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useEffect, useState, useCallback, useSyncExternalStore } from "react";
-import { Moon, Sun, Brain } from "lucide-react";
+import { Moon, Sun, Brain, LogIn, LogOut, User } from "lucide-react";
+import Link from "next/link";
 import { cn } from "@/lib/utils";
+import { useWorkspace } from "@/context/WorkspaceContext";
 
 // Theme store using useSyncExternalStore pattern
 const themeStore = {
@@ -30,6 +32,7 @@ const themeStore = {
 };
 
 export default function Header() {
+  const { user, isLoggedIn, logout } = useWorkspace();
   const theme = useSyncExternalStore(
     themeStore.subscribe,
     themeStore.getSnapshot,
@@ -89,27 +92,73 @@ export default function Header() {
         </div>
       </div>
 
-      {/* Theme Toggle */}
-      {mounted ? (
-        <button
-          onClick={toggleTheme}
-          className={cn(
-            "relative flex h-9 w-9 items-center justify-center rounded-lg",
-            "border border-border bg-surface text-foreground-secondary",
-            "transition-all duration-200 hover:bg-surface-elevated hover:text-foreground",
-            "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
-          )}
-          aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
-        >
-          {theme === "dark" ? (
-            <Sun className="h-4 w-4" />
+      {/* Right side: workspace + theme toggle */}
+      <div className="flex items-center gap-2">
+        {/* Workspace user pill or sign-in link */}
+        {mounted && (
+          isLoggedIn && user ? (
+            <div className="flex items-center gap-2">
+              <Link
+                href="/workspace"
+                className={cn(
+                  "flex items-center gap-1.5 rounded-lg border border-accent/40 bg-accent-muted",
+                  "px-3 py-1.5 text-xs font-medium text-accent",
+                  "transition-colors hover:bg-accent/20"
+                )}
+              >
+                <User className="h-3 w-3" />
+                <span className="max-w-[140px] truncate">{user.email}</span>
+              </Link>
+              <button
+                onClick={logout}
+                className={cn(
+                  "flex h-9 w-9 items-center justify-center rounded-lg",
+                  "border border-border bg-surface text-foreground-secondary",
+                  "transition-all duration-200 hover:bg-surface-elevated hover:text-foreground"
+                )}
+                aria-label="Sign out of workspace"
+                title="Sign out"
+              >
+                <LogOut className="h-4 w-4" />
+              </button>
+            </div>
           ) : (
-            <Moon className="h-4 w-4" />
-          )}
-        </button>
-      ) : (
-        <div className="h-9 w-9" />
-      )}
+            <Link
+              href="/workspace"
+              className={cn(
+                "flex items-center gap-1.5 rounded-lg border border-border bg-surface",
+                "px-3 py-1.5 text-xs font-medium text-foreground-secondary",
+                "transition-colors hover:bg-surface-elevated hover:text-foreground"
+              )}
+            >
+              <LogIn className="h-3.5 w-3.5" />
+              <span>Sign in</span>
+            </Link>
+          )
+        )}
+
+        {/* Theme Toggle */}
+        {mounted ? (
+          <button
+            onClick={toggleTheme}
+            className={cn(
+              "relative flex h-9 w-9 items-center justify-center rounded-lg",
+              "border border-border bg-surface text-foreground-secondary",
+              "transition-all duration-200 hover:bg-surface-elevated hover:text-foreground",
+              "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
+            )}
+            aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+          >
+            {theme === "dark" ? (
+              <Sun className="h-4 w-4" />
+            ) : (
+              <Moon className="h-4 w-4" />
+            )}
+          </button>
+        ) : (
+          <div className="h-9 w-9" />
+        )}
+      </div>
     </>
   );
 

--- a/ui/app/components/results/VolumeStatsPanel.tsx
+++ b/ui/app/components/results/VolumeStatsPanel.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState } from "react";
+import { getModelStats, ModelStatsResponse } from "@/lib/api";
+import { BarChart2, ChevronDown, ChevronUp, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  sessionId: string;
+  modelName: string;
+}
+
+export function VolumeStatsPanel({ sessionId, modelName }: Props) {
+  const [open, setOpen] = useState(false);
+  const [stats, setStats] = useState<ModelStatsResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleToggle() {
+    if (open) {
+      setOpen(false);
+      return;
+    }
+    setOpen(true);
+    if (stats) return; // already loaded
+
+    setLoading(true);
+    setError("");
+    try {
+      const result = await getModelStats(sessionId, modelName);
+      setStats(result);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to load stats");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  // Compute brain volume (labels 1–11, excluding background 0)
+  const brainVolume = stats
+    ? Object.entries(stats.labels)
+        .filter(([id]) => id !== "0")
+        .reduce((sum, [, v]) => sum + v.volume_mm3, 0)
+    : 0;
+
+  return (
+    <div className="mt-2 rounded-lg border border-border overflow-hidden">
+      {/* Toggle button */}
+      <button
+        onClick={handleToggle}
+        className={cn(
+          "flex w-full items-center justify-between px-3 py-2",
+          "bg-surface text-xs font-medium text-foreground-secondary",
+          "hover:bg-surface-elevated transition-colors"
+        )}
+      >
+        <span className="flex items-center gap-1.5">
+          <BarChart2 className="h-3.5 w-3.5 text-accent" />
+          Tissue volumes
+        </span>
+        {open ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+      </button>
+
+      {/* Content */}
+      {open && (
+        <div className="bg-surface-elevated">
+          {loading && (
+            <div className="flex items-center justify-center gap-2 py-4 text-xs text-foreground-muted">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Computing volumes…
+            </div>
+          )}
+
+          {error && (
+            <p className="px-3 py-3 text-xs text-red-400">{error}</p>
+          )}
+
+          {stats && !loading && (
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b border-border text-foreground-muted">
+                    <th className="px-3 py-2 text-left font-medium">Tissue</th>
+                    <th className="px-3 py-2 text-right font-medium">Volume (mm³)</th>
+                    <th className="px-3 py-2 text-right font-medium">% Brain</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {Object.entries(stats.labels).map(([id, label]) => {
+                    const pct =
+                      id === "0" || brainVolume === 0
+                        ? null
+                        : ((label.volume_mm3 / brainVolume) * 100).toFixed(1);
+                    return (
+                      <tr
+                        key={id}
+                        className={cn(
+                          "border-b border-border/50 hover:bg-surface transition-colors",
+                          id === "0" && "text-foreground-muted"
+                        )}
+                      >
+                        <td className="px-3 py-1.5">
+                          <span className="flex items-center gap-1.5">
+                            <span
+                              className="h-2 w-2 rounded-full shrink-0"
+                              style={{ background: getLabelColor(Number(id)) }}
+                            />
+                            {label.name}
+                          </span>
+                        </td>
+                        <td className="px-3 py-1.5 text-right tabular-nums">
+                          {label.volume_mm3.toLocaleString()}
+                        </td>
+                        <td className="px-3 py-1.5 text-right tabular-nums text-foreground-muted">
+                          {pct !== null ? `${pct}%` : "—"}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+                <tfoot>
+                  <tr className="border-t border-border text-foreground-muted">
+                    <td className="px-3 py-2 text-xs" colSpan={3}>
+                      Voxel size: {stats.voxel_volume_mm3} mm³
+                    </td>
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Simple colour map matching the segmentation legend (indices 0–11)
+function getLabelColor(id: number): string {
+  const colors = [
+    "#374151", // 0 Background — grey
+    "#e5e7eb", // 1 White Matter
+    "#9ca3af", // 2 Grey Matter
+    "#60a5fa", // 3 Eyes
+    "#93c5fd", // 4 CSF
+    "#d1d5db", // 5 Air
+    "#f87171", // 6 Blood
+    "#fcd34d", // 7 Spongy Bone
+    "#f9a825", // 8 Compact Bone
+    "#fdba74", // 9 Skin
+    "#fde68a", // 10 Fat
+    "#86efac", // 11 Muscle
+  ];
+  return colors[id] ?? "#6b7280";
+}

--- a/ui/app/components/wizard/steps/ConfigureStep.tsx
+++ b/ui/app/components/wizard/steps/ConfigureStep.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { ArrowLeft, ArrowRight, Brain, Boxes, Sparkles, Check } from "lucide-react";
+import { useState } from "react";
+import { ArrowLeft, ArrowRight, Brain, Boxes, Sparkles, Check, Bell } from "lucide-react";
 import { useJob, Space, ModelSelection } from "@/context/JobContext";
+import { useWorkspace } from "@/context/WorkspaceContext";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -66,6 +68,9 @@ export default function ConfigureStep() {
     status,
   } = useJob();
 
+  const { user, isLoggedIn } = useWorkspace();
+  const [notifyEmail, setNotifyEmail] = useState("");
+
   const handleModelToggle = (modelId: keyof ModelSelection) => {
     setSelectedModels((prev) => ({
       ...prev,
@@ -79,7 +84,10 @@ export default function ConfigureStep() {
 
   const handleStart = async () => {
     if (isAnyModelSelected) {
-      await startJob();
+      await startJob({
+        notifyEmail: isLoggedIn ? (user?.email ?? "") : notifyEmail,
+        workspaceJwt: user?.token,
+      });
     }
   };
 
@@ -237,6 +245,37 @@ export default function ConfigureStep() {
             after your session ends.
           </p>
         </div>
+      </div>
+
+      {/* Notify email */}
+      <div className="rounded-2xl border border-border bg-surface p-5 shadow-medical">
+        <h2 className="mb-3 text-[10px] font-bold uppercase tracking-widest font-mono text-accent flex items-center gap-1.5">
+          <Bell className="h-3 w-3" />
+          // Notify on Completion
+        </h2>
+        {isLoggedIn && user ? (
+          <p className="text-sm text-foreground-secondary">
+            We'll email <strong className="text-foreground">{user.email}</strong> when your job finishes.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="notify-email" className="text-xs text-foreground-muted">
+              Email address <span className="text-foreground-muted">(optional)</span>
+            </label>
+            <input
+              id="notify-email"
+              type="email"
+              value={notifyEmail}
+              onChange={(e) => setNotifyEmail(e.target.value)}
+              placeholder="you@example.com"
+              className={cn(
+                "w-full max-w-xs rounded-lg border border-border bg-surface-elevated px-3 py-2 text-sm",
+                "text-foreground placeholder:text-foreground-muted",
+                "focus:outline-none focus:ring-2 focus:ring-ring"
+              )}
+            />
+          </div>
+        )}
       </div>
 
       {/* Navigation */}

--- a/ui/app/components/wizard/steps/ResultsStep.tsx
+++ b/ui/app/components/wizard/steps/ResultsStep.tsx
@@ -7,6 +7,7 @@ import { useJob } from "@/context/JobContext";
 import { Button } from "@/components/ui/button";
 import SplitViewer from "../../viewer/SplitViewer";
 import { API_BASE, deleteSession } from "@/lib/api";
+import { VolumeStatsPanel } from "../../results/VolumeStatsPanel";
 
 const ACTIVE_SIM_KEY = "grace_active_sim";
 type SavedSim = { sessionId: string; model: string; solver: "roast" | "simnibs"; startedAt: number };
@@ -222,15 +223,20 @@ export default function ResultsStep() {
         </h2>
         <div className="grid gap-4 md:grid-cols-3">
           {models.map(model => (
-            <div key={model} className="flex items-center justify-between rounded-xl border border-border bg-background p-4">
-              <div>
-                <h3 className="font-mono font-bold tracking-wide text-foreground">{getDisplayName(model)}</h3>
-                <span className="mt-1 inline-block rounded border border-border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest text-foreground-muted">{getSpaceLabel(model)}</span>
+            <div key={model} className="flex flex-col rounded-xl border border-border bg-background p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <h3 className="font-mono font-bold tracking-wide text-foreground">{getDisplayName(model)}</h3>
+                  <span className="mt-1 inline-block rounded border border-border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest text-foreground-muted">{getSpaceLabel(model)}</span>
+                </div>
+                <Button variant="success" size="sm" onClick={() => handleDownload(model)} className="gap-1.5">
+                  <Download className="h-3.5 w-3.5" />
+                  Download
+                </Button>
               </div>
-              <Button variant="success" size="sm" onClick={() => handleDownload(model)} className="gap-1.5">
-                <Download className="h-3.5 w-3.5" />
-                Download
-              </Button>
+              {sessionId && (
+                <VolumeStatsPanel sessionId={sessionId} modelName={model} />
+              )}
             </div>
           ))}
         </div>

--- a/ui/app/workspace/page.tsx
+++ b/ui/app/workspace/page.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useWorkspace } from "@/context/WorkspaceContext";
+import { requestMagicLink, getWorkspaceSessions, deleteWorkspaceAccount } from "@/lib/workspaceApi";
+import { Loader2, Mail, Trash2, FolderOpen, AlertTriangle, CheckCircle } from "lucide-react";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Sign-in form (anonymous user)
+// ---------------------------------------------------------------------------
+
+function SignInForm() {
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "sent" | "error">("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setStatus("loading");
+    setErrorMsg("");
+    try {
+      await requestMagicLink(email.trim());
+      setStatus("sent");
+    } catch (err: unknown) {
+      setErrorMsg(err instanceof Error ? err.message : "Failed to send link");
+      setStatus("error");
+    }
+  }
+
+  if (status === "sent") {
+    return (
+      <div className="flex flex-col items-center gap-4 py-8 text-center">
+        <CheckCircle className="h-12 w-12 text-green-500" />
+        <h2 className="text-lg font-semibold text-foreground">Check your email</h2>
+        <p className="text-sm text-foreground-muted max-w-sm">
+          We sent a sign-in link to <strong>{email}</strong>. It expires in 15 minutes.
+        </p>
+        <button
+          onClick={() => setStatus("idle")}
+          className="text-xs text-foreground-muted underline underline-offset-2"
+        >
+          Use a different email
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <div>
+        <label htmlFor="email" className="block text-sm font-medium text-foreground mb-1">
+          Email address
+        </label>
+        <input
+          id="email"
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@example.com"
+          className={cn(
+            "w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm",
+            "text-foreground placeholder:text-foreground-muted",
+            "focus:outline-none focus:ring-2 focus:ring-ring"
+          )}
+        />
+      </div>
+
+      {status === "error" && (
+        <p className="text-xs text-red-400">{errorMsg}</p>
+      )}
+
+      <button
+        type="submit"
+        disabled={status === "loading"}
+        className={cn(
+          "flex items-center justify-center gap-2 rounded-lg bg-accent px-4 py-2",
+          "text-sm font-medium text-accent-foreground",
+          "transition-colors hover:bg-accent-hover disabled:opacity-60"
+        )}
+      >
+        {status === "loading" ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Mail className="h-4 w-4" />
+        )}
+        Send sign-in link
+      </button>
+    </form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Workspace dashboard (logged-in user)
+// ---------------------------------------------------------------------------
+
+function WorkspaceDashboard() {
+  const { user, logout } = useWorkspace();
+  const [sessions, setSessions] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [deleteConfirm, setDeleteConfirm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    if (!user) return;
+    getWorkspaceSessions(user.token)
+      .then((r) => setSessions(r.sessions))
+      .catch(() => setSessions([]))
+      .finally(() => setLoading(false));
+  }, [user]);
+
+  async function handleDeleteAccount() {
+    if (!user) return;
+    setDeleting(true);
+    try {
+      await deleteWorkspaceAccount(user.token);
+      logout();
+    } catch (err: unknown) {
+      alert(err instanceof Error ? err.message : "Failed to delete workspace");
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Profile */}
+      <div className="rounded-xl border border-border bg-surface p-4">
+        <p className="text-xs text-foreground-muted mb-1">Signed in as</p>
+        <p className="text-sm font-semibold text-foreground">{user?.email}</p>
+        <p className="text-xs text-foreground-muted mt-1">
+          Session retention: <strong>{user?.retention_days} days</strong>
+        </p>
+      </div>
+
+      {/* Sessions */}
+      <div>
+        <h3 className="text-sm font-medium text-foreground mb-2">Your sessions</h3>
+        {loading ? (
+          <div className="flex items-center gap-2 text-xs text-foreground-muted">
+            <Loader2 className="h-3 w-3 animate-spin" /> Loading...
+          </div>
+        ) : sessions.length === 0 ? (
+          <p className="text-xs text-foreground-muted">
+            No saved sessions yet.{" "}
+            <Link href="/" className="text-accent underline underline-offset-2">
+              Start a segmentation
+            </Link>{" "}
+            to create one.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {sessions.map((sid) => (
+              <li
+                key={sid}
+                className="flex items-center gap-2 rounded-lg border border-border bg-surface-elevated px-3 py-2"
+              >
+                <FolderOpen className="h-3.5 w-3.5 text-foreground-muted shrink-0" />
+                <code className="text-xs text-foreground flex-1 truncate">{sid}</code>
+                <Link
+                  href={`/?session=${sid}`}
+                  className="text-xs text-accent hover:underline underline-offset-2 shrink-0"
+                >
+                  Open
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Danger zone */}
+      <div className="rounded-xl border border-red-500/30 bg-red-500/5 p-4">
+        <h3 className="text-sm font-semibold text-red-400 flex items-center gap-1.5 mb-2">
+          <AlertTriangle className="h-4 w-4" />
+          Delete workspace
+        </h3>
+        <p className="text-xs text-foreground-muted mb-3">
+          Permanently deletes your account and all session data. This cannot be undone.
+        </p>
+        {!deleteConfirm ? (
+          <button
+            onClick={() => setDeleteConfirm(true)}
+            className="flex items-center gap-1.5 rounded-lg border border-red-500/40 px-3 py-1.5 text-xs font-medium text-red-400 hover:bg-red-500/10 transition-colors"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+            Delete my workspace
+          </button>
+        ) : (
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleDeleteAccount}
+              disabled={deleting}
+              className="flex items-center gap-1.5 rounded-lg bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700 transition-colors disabled:opacity-60"
+            >
+              {deleting ? <Loader2 className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
+              Confirm — delete everything
+            </button>
+            <button
+              onClick={() => setDeleteConfirm(false)}
+              className="text-xs text-foreground-muted hover:text-foreground"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function WorkspacePage() {
+  const { isLoggedIn } = useWorkspace();
+
+  return (
+    <div className="container mx-auto max-w-lg px-4 py-12">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-foreground mb-1">Workspace</h1>
+        <p className="text-sm text-foreground-muted">
+          {isLoggedIn
+            ? "Manage your saved sessions and account."
+            : "Sign in to save your sessions for longer and access them from any device."}
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-border bg-surface p-6 shadow-medical-lg">
+        {isLoggedIn ? <WorkspaceDashboard /> : <SignInForm />}
+      </div>
+
+      {!isLoggedIn && (
+        <p className="mt-4 text-center text-xs text-foreground-muted">
+          No account needed to use CROWN. Sign in only if you want longer session retention.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/ui/app/workspace/verify/page.tsx
+++ b/ui/app/workspace/verify/page.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { useWorkspace } from "@/context/WorkspaceContext";
+import { verifyMagicToken } from "@/lib/workspaceApi";
+import { Loader2, CheckCircle, XCircle } from "lucide-react";
+import Link from "next/link";
+
+export default function WorkspaceVerifyPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { login } = useWorkspace();
+
+  const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  useEffect(() => {
+    const token = searchParams.get("token");
+    if (!token) {
+      setErrorMsg("No sign-in token found in URL.");
+      setStatus("error");
+      return;
+    }
+
+    verifyMagicToken(token)
+      .then(({ token: jwt, email, retention_days }) => {
+        login(jwt, email, retention_days);
+        setStatus("success");
+        setTimeout(() => router.push("/workspace"), 1500);
+      })
+      .catch((err: unknown) => {
+        setErrorMsg(err instanceof Error ? err.message : "Invalid or expired sign-in link");
+        setStatus("error");
+      });
+  }, [searchParams, login, router]);
+
+  return (
+    <div className="container mx-auto max-w-md px-4 py-24 flex flex-col items-center text-center gap-4">
+      {status === "loading" && (
+        <>
+          <Loader2 className="h-12 w-12 animate-spin text-accent" />
+          <p className="text-sm text-foreground-muted">Verifying your sign-in link…</p>
+        </>
+      )}
+
+      {status === "success" && (
+        <>
+          <CheckCircle className="h-12 w-12 text-green-500" />
+          <h2 className="text-lg font-semibold text-foreground">Signed in!</h2>
+          <p className="text-sm text-foreground-muted">Redirecting to your workspace…</p>
+        </>
+      )}
+
+      {status === "error" && (
+        <>
+          <XCircle className="h-12 w-12 text-red-400" />
+          <h2 className="text-lg font-semibold text-foreground">Sign-in failed</h2>
+          <p className="text-sm text-foreground-muted">{errorMsg}</p>
+          <Link
+            href="/workspace"
+            className="mt-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground hover:bg-accent-hover transition-colors"
+          >
+            Request a new link
+          </Link>
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui/context/JobContext.tsx
+++ b/ui/context/JobContext.tsx
@@ -83,7 +83,7 @@ interface JobContextType {
   getSelectedModelList: () => string[];
 
   // Actions
-  startJob: () => Promise<void>;
+  startJob: (opts?: { notifyEmail?: string; workspaceJwt?: string }) => Promise<void>;
   resetJob: () => void;
 
   // Setters
@@ -244,7 +244,7 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
   // ------------------------------------------------------------
   // START A NEW JOB
   // ------------------------------------------------------------
-  const startJob = useCallback(async () => {
+  const startJob = useCallback(async (opts?: { notifyEmail?: string; workspaceJwt?: string }) => {
     if (!selectedFile || !isAnyModelSelected) return;
 
     setStatus("uploading");
@@ -260,7 +260,9 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
       selectedFile,
       modelList,
       selectedSpace,
-      shouldConvertToFs
+      shouldConvertToFs,
+      opts?.workspaceJwt,
+      opts?.notifyEmail,
     );
 
     setSessionId(resp.session_id);

--- a/ui/context/WorkspaceContext.tsx
+++ b/ui/context/WorkspaceContext.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, useCallback, ReactNode } from "react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WorkspaceUser {
+  token: string;
+  email: string;
+  retention_days: number;
+  expires_at: number; // epoch ms
+}
+
+interface WorkspaceContextType {
+  user: WorkspaceUser | null;
+  isLoggedIn: boolean;
+  login: (token: string, email: string, retention_days: number) => void;
+  logout: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+const WorkspaceContext = createContext<WorkspaceContextType>({
+  user: null,
+  isLoggedIn: false,
+  login: () => {},
+  logout: () => {},
+});
+
+const STORAGE_KEY = "grace_workspace_jwt";
+// JWT default is 8 hours (480 min); store expiry locally
+const JWT_LIFETIME_MS = 8 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export function WorkspaceProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<WorkspaceUser | null>(null);
+
+  // Load from localStorage on mount
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const stored: WorkspaceUser = JSON.parse(raw);
+      if (stored.expires_at > Date.now()) {
+        setUser(stored);
+      } else {
+        localStorage.removeItem(STORAGE_KEY);
+      }
+    } catch {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  const login = useCallback((token: string, email: string, retention_days: number) => {
+    const user: WorkspaceUser = {
+      token,
+      email,
+      retention_days,
+      expires_at: Date.now() + JWT_LIFETIME_MS,
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(user));
+    setUser(user);
+  }, []);
+
+  const logout = useCallback(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    setUser(null);
+  }, []);
+
+  return (
+    <WorkspaceContext.Provider value={{ user, isLoggedIn: !!user, login, logout }}>
+      {children}
+    </WorkspaceContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useWorkspace() {
+  return useContext(WorkspaceContext);
+}

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -43,13 +43,31 @@ export interface SSEEvent {
 }
 
 // ---------------------------------------------------------------------
+// Tissue volume stats types
+// ---------------------------------------------------------------------
+export interface LabelStats {
+  name: string;
+  voxel_count: number;
+  volume_mm3: number;
+}
+
+export interface ModelStatsResponse {
+  session_id: string;
+  model_name: string;
+  voxel_volume_mm3: number;
+  labels: Record<string, LabelStats>;
+}
+
+// ---------------------------------------------------------------------
 // POST /predict
 // ---------------------------------------------------------------------
 export async function startPrediction(
   file: File,
   models: string[],
   space: string,
-  convertToFs: boolean = false
+  convertToFs: boolean = false,
+  workspaceJwt?: string,
+  notifyEmail?: string
 ): Promise<PredictResponse> {
   console.log(models);
   console.log(space);
@@ -57,12 +75,17 @@ export async function startPrediction(
   formData.append("file", file);
   formData.append("space", space);
   formData.append("convert_to_fs", convertToFs ? "true" : "false");
+  if (notifyEmail) formData.append("notify_email", notifyEmail);
 
   if (models.length === 6) formData.append("models", "all");
   else formData.append("models", models.join(","));
 
+  const headers: Record<string, string> = {};
+  if (workspaceJwt) headers["Authorization"] = `Bearer ${workspaceJwt}`;
+
   const res = await fetch(`${API_BASE}/predict`, {
     method: "POST",
+    headers,
     body: formData,
   });
 
@@ -419,6 +442,21 @@ export async function restoreSession(
     throw new Error(detail);
   }
   return await res.json();
+}
+
+// ---------------------------------------------------------------------
+// GET /results/{session_id}/{model_name}/stats
+// ---------------------------------------------------------------------
+export async function getModelStats(
+  sessionId: string,
+  modelName: string,
+): Promise<ModelStatsResponse> {
+  const res = await fetch(`${API_BASE}/results/${sessionId}/${modelName}/stats`);
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail || "Failed to fetch volume stats");
+  }
+  return res.json();
 }
 
 // ---------------------------------------------------------------------

--- a/ui/lib/workspaceApi.ts
+++ b/ui/lib/workspaceApi.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { API_BASE } from "./api";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MagicLinkResponse {
+  status: string;
+}
+
+export interface VerifyTokenResponse {
+  token: string;
+  email: string;
+  retention_days: number;
+}
+
+export interface WorkspaceMeResponse {
+  id: number;
+  email: string;
+  created_at: string;
+  last_login: string | null;
+  retention_days: number;
+}
+
+export interface WorkspaceSessionsResponse {
+  sessions: string[];
+}
+
+export interface DeleteAccountResponse {
+  deleted: boolean;
+  sessions_removed: number;
+}
+
+// ---------------------------------------------------------------------------
+// API calls
+// ---------------------------------------------------------------------------
+
+export async function requestMagicLink(email: string): Promise<MagicLinkResponse> {
+  const res = await fetch(`${API_BASE}/workspace/request-magic-link`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email }),
+  });
+  if (res.status === 429) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail || "Too many requests. Please wait before trying again.");
+  }
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail || "Failed to send sign-in link");
+  }
+  return res.json();
+}
+
+export async function verifyMagicToken(token: string): Promise<VerifyTokenResponse> {
+  const res = await fetch(`${API_BASE}/workspace/verify/${encodeURIComponent(token)}`);
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail || "Invalid or expired sign-in link");
+  }
+  return res.json();
+}
+
+export async function getWorkspaceMe(jwt: string): Promise<WorkspaceMeResponse> {
+  const res = await fetch(`${API_BASE}/workspace/me`, {
+    headers: { Authorization: `Bearer ${jwt}` },
+  });
+  if (!res.ok) throw new Error("Failed to fetch workspace profile");
+  return res.json();
+}
+
+export async function getWorkspaceSessions(jwt: string): Promise<WorkspaceSessionsResponse> {
+  const res = await fetch(`${API_BASE}/workspace/sessions`, {
+    headers: { Authorization: `Bearer ${jwt}` },
+  });
+  if (!res.ok) throw new Error("Failed to fetch sessions");
+  return res.json();
+}
+
+export async function deleteWorkspaceAccount(jwt: string): Promise<DeleteAccountResponse> {
+  const res = await fetch(`${API_BASE}/workspace/account`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${jwt}` },
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail || "Failed to delete workspace");
+  }
+  return res.json();
+}


### PR DESCRIPTION
- Workspace: optional user accounts via magic-link auth (no password). Workspace users get configurable retention (default 7d vs 24h anon). One-click account deletion removes all sessions + files. Role-separated JWTs: require_admin_jwt blocks workspace tokens from /admin/*. Magic tokens use secrets.token_urlsafe(32), one-time use, 15-min TTL, rate-limited.

- Volume stats: GET /results/{sid}/{model}/stats returns per-label mm³ volumes for all 12 tissue classes. Cached as stats.json; collapsible panel in Results step.

- Completion emails: optional notify_email field at upload time. Workspace users auto-notified via their account email. Atomic redis GETDEL prevents duplicate sends. Fires after segmentation, ROAST, and SimNIBS completion.

New files: workspace_db.py, notify.py, volume_stats.py,
  WorkspaceContext.tsx, workspaceApi.ts,
  workspace/page.tsx, workspace/verify/page.tsx,
  VolumeStatsPanel.tsx