### PR TITLE
feat(ui): cancel button, session restore, and job persistence on reload

### DIFF
--- a/ui/app/components/wizard/WizardShell.tsx
+++ b/ui/app/components/wizard/WizardShell.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useJob, WizardStep } from "@/context/JobContext";
+import { restoreSession } from "@/lib/api";
 import Stepper from "./Stepper";
 import UploadStep from "./steps/UploadStep";
 import ConfigureStep from "./steps/ConfigureStep";
@@ -25,7 +27,29 @@ export default function WizardShell() {
     setError,
     sseDisconnected,
     setSseDisconnected,
+    restoreJobFromSession,
   } = useJob();
+
+  const [restoreError, setRestoreError] = useState<string | null>(null);
+
+  // Detect ?restore=token on mount and load the session
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const token = params.get("restore");
+    if (!token) return;
+
+    // Clean the URL immediately
+    window.history.replaceState({}, "", "/");
+
+    restoreSession(token)
+      .then(({ session_id, models }) => {
+        restoreJobFromSession(session_id, models);
+      })
+      .catch((err: unknown) => {
+        setRestoreError(err instanceof Error ? err.message : "Restore link is invalid or has expired.");
+      });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Navigation handlers
   const canNavigateTo = (step: WizardStep): boolean => {
@@ -61,6 +85,14 @@ export default function WizardShell() {
     <>
       {/* Skip Link for keyboard navigation */}
       <SkipLink />
+
+      {/* Restore error banner */}
+      {restoreError && (
+        <div className="border-b border-red-500/30 bg-red-500/10 px-4 py-2 text-center text-xs text-red-400 flex items-center justify-center gap-2">
+          <span>{restoreError}</span>
+          <button onClick={() => setRestoreError(null)} className="underline underline-offset-2 hover:text-red-300">Dismiss</button>
+        </div>
+      )}
 
       {/* Error Modal */}
       <ErrorModal

--- a/ui/app/components/wizard/steps/ProcessingStep.tsx
+++ b/ui/app/components/wizard/steps/ProcessingStep.tsx
@@ -1,12 +1,23 @@
 "use client";
 
+import { useState } from "react";
+import { X, Loader2 } from "lucide-react";
 import { useJob } from "@/context/JobContext";
+import { cancelJob } from "@/lib/api";
 import OverallProgress from "../../progress/OverallProgress";
 import ModelProgressCard from "../../progress/ModelProgressCard";
 import GPUStatus from "../../GPUStatus";
 
 export default function ProcessingStep() {
-  const { models, progress, modelGpus, status, sessionId, queuePosition, selectedFile } = useJob();
+  const { models, progress, modelGpus, status, sessionId, queuePosition, selectedFile, resetJob } = useJob();
+  const [cancelling, setCancelling] = useState(false);
+
+  const handleCancel = async () => {
+    if (!sessionId || cancelling) return;
+    setCancelling(true);
+    await cancelJob(sessionId).catch(() => {});
+    resetJob();
+  };
 
   // Calculate overall progress
   const totalProgress = models.length > 0
@@ -65,6 +76,22 @@ export default function ProcessingStep() {
                 {sessionId.slice(0, 8)}...
               </p>
             </div>
+          )}
+
+          {/* Cancel button — only while job is active */}
+          {(status === "queued" || status === "running") && (
+            <button
+              onClick={handleCancel}
+              disabled={cancelling}
+              className="mt-4 w-full flex items-center justify-center gap-1.5 rounded-lg border border-red-500/40 px-3 py-2 text-xs font-medium text-red-400 hover:bg-red-500/10 transition-colors disabled:opacity-50"
+            >
+              {cancelling ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <X className="h-3.5 w-3.5" />
+              )}
+              {cancelling ? "Cancelling…" : "Cancel job"}
+            </button>
           )}
         </div>
 

--- a/ui/context/JobContext.tsx
+++ b/ui/context/JobContext.tsx
@@ -17,9 +17,9 @@ import {
   PredictResponse,
 } from "../lib/api";
 
-// ── Persist completed session so TES page survives page reload / deployment ──
+// ── Persist session so TES page and in-progress jobs survive page reload ──
 const SEG_SESSION_KEY = "grace_seg_session";
-type PersistedSession = { sessionId: string; models: string[]; space: string };
+type PersistedSession = { sessionId: string; models: string[]; space: string; status?: string };
 function saveSegSession(s: PersistedSession) {
   try { localStorage.setItem(SEG_SESSION_KEY, JSON.stringify(s)); } catch {}
 }
@@ -85,6 +85,7 @@ interface JobContextType {
   // Actions
   startJob: (opts?: { notifyEmail?: string; workspaceJwt?: string }) => Promise<void>;
   resetJob: () => void;
+  restoreJobFromSession: (sessionId: string, models: string[], space?: string) => void;
 
   // Setters
   setError: (m: string | null) => void;
@@ -181,12 +182,32 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
     }
   }, [status, viewerReady, currentStep]);
 
-  // Persist session to localStorage when complete so TES page survives reload
+  // Persist session state (queued/running/complete) so reload can reconnect
   useEffect(() => {
-    if (status === "complete" && sessionId && models.length > 0) {
-      saveSegSession({ sessionId, models, space });
+    if (sessionId && models.length > 0 && (status === "queued" || status === "running" || status === "complete")) {
+      saveSegSession({ sessionId, models, space, status });
     }
   }, [status, sessionId, models, space]);
+
+  // On mount: restore in-progress or completed session from localStorage
+  useEffect(() => {
+    const saved = loadSegSession();
+    if (!saved) return;
+    const { sessionId: sid, models: savedModels, space: savedSpace, status: savedStatus } = saved;
+    if (!sid || !savedModels?.length) return;
+
+    if (savedStatus === "queued" || savedStatus === "running") {
+      // Reconnect SSE for in-progress job
+      setSessionId(sid);
+      setModels(savedModels);
+      setSpace(savedSpace ?? "native");
+      setStatus(savedStatus as "queued" | "running");
+      setCurrentStep(3);
+      subscribeToSSE(sid, 0);
+    }
+    // complete case handled by TES page / WizardShell restore flow
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // ------------------------------------------------------------
   // SSE SUBSCRIBE
@@ -284,6 +305,19 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
   }, [selectedFile, isAnyModelSelected, getSelectedModelList, selectedSpace, convertToFs, subscribeToSSE]);
 
   // ------------------------------------------------------------
+  // RESTORE SESSION (from email link or localStorage)
+  // ------------------------------------------------------------
+  const restoreJobFromSession = useCallback((sid: string, savedModels: string[], savedSpace = "native") => {
+    setSessionId(sid);
+    setModels(savedModels);
+    setSpace(savedSpace);
+    setStatus("complete");
+    setViewerReady(true);
+    setCurrentStep(4);
+    saveSegSession({ sessionId: sid, models: savedModels, space: savedSpace, status: "complete" });
+  }, []);
+
+  // ------------------------------------------------------------
   // RESET JOB COMPLETELY
   // ------------------------------------------------------------
   const resetJob = useCallback(() => {
@@ -371,6 +405,7 @@ export function JobProvider({ children }: { children: React.ReactNode }) {
         // Actions
         startJob,
         resetJob,
+        restoreJobFromSession,
         setError,
         setSseDisconnected,
       }}


### PR DESCRIPTION
- ProcessingStep: Cancel job button visible while queued/running; calls /cancel/{session_id} then resetJob() to return to step 1

- WizardShell: detect ?restore=token on mount, call /session/restore/{token}, load session into JobContext step 4. Shows inline error banner on failure.

- JobContext: restoreJobFromSession() action sets complete state + jumps to step 4. In-progress sessions (queued/running) now persisted to localStorage and reconnected via SSE on page reload, restoring step 3 automatically.